### PR TITLE
[DIDA] fix. Paging > 페이징 관련 데이터 이벤트 발생시(좋아요 클릭등) 페이지 처음부터 가져오던 내용 수정

### DIFF
--- a/feature/community/src/main/java/com/dida/community/adapter/PostsPagingSource.kt
+++ b/feature/community/src/main/java/com/dida/community/adapter/PostsPagingSource.kt
@@ -4,6 +4,7 @@ import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
+import com.dida.domain.NetworkResult
 import com.dida.domain.fold
 import com.dida.domain.model.main.Posts
 import com.dida.domain.usecase.main.PostsAPI
@@ -13,29 +14,29 @@ fun createPostsPager(
 ): Pager<Int, Posts> = Pager(
     config = PagingConfig(pageSize = 20, initialLoadSize = 20, enablePlaceholders = true),
     initialKey = 0,
-    pagingSourceFactory = {
-        PostsPagingSource(
-            postsAPI = postsAPI
-        )
-    }
+    pagingSourceFactory = { PostsPagingSource(postsAPI = postsAPI) }
 )
 
 class PostsPagingSource(
     private val postsAPI: PostsAPI
 ) : PagingSource<Int, Posts>() {
 
-    override fun getRefreshKey(state: PagingState<Int, Posts>): Int? = null
+    override fun getRefreshKey(state: PagingState<Int, Posts>): Int? {
+        return state.anchorPosition?.let { anchorPosition ->
+            state.closestPageToPosition(anchorPosition)?.prevKey?.plus(1)
+                ?: state.closestPageToPosition(anchorPosition)?.nextKey?.minus(1)
+        }
+    }
 
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Posts> {
         val pageIndex = params.key ?: 0
-        val result = postsAPI.invoke(
-            page = pageIndex
-        )
+        val result = postsAPI.invoke(page = pageIndex)
+
         return result.fold(
             onSuccess = { contents ->
                 LoadResult.Page(
                     data = contents,
-                    prevKey = null,
+                    prevKey = if (pageIndex == 0) null else pageIndex - 1,
                     nextKey = if(contents.isNotEmpty()) pageIndex+1 else null
                 )
             },

--- a/feature/hot-seller/src/main/java/com/dida/hot_seller/adapter/HotSellerPagingSource.kt
+++ b/feature/hot-seller/src/main/java/com/dida/hot_seller/adapter/HotSellerPagingSource.kt
@@ -20,17 +20,23 @@ class HotSellerPagingSource(
     private val hotSellerAPI: HotSellerAPI
 ) : PagingSource<Int, HotSellerMore>() {
 
-    override fun getRefreshKey(state: PagingState<Int, HotSellerMore>): Int? = null
+    override fun getRefreshKey(state: PagingState<Int, HotSellerMore>): Int? {
+        return state.anchorPosition?.let { anchorPosition ->
+            state.closestPageToPosition(anchorPosition)?.prevKey?.plus(1)
+                ?: state.closestPageToPosition(anchorPosition)?.nextKey?.minus(1)
+        }
+    }
 
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, HotSellerMore> {
         val pageIndex = params.key ?: 0
         val result = hotSellerAPI(page = pageIndex)
+
         return result.fold(
             onSuccess = { contents ->
                 LoadResult.Page(
                     data = contents,
-                    prevKey = null,
-                    nextKey = if(contents.isNotEmpty()) pageIndex+1 else null
+                    prevKey = if (pageIndex == 0) null else pageIndex - 1,
+                    nextKey = if(contents.isNotEmpty()) pageIndex + 1 else null
                 )
             },
             onError = { e -> LoadResult.Error(e) }

--- a/feature/hot-user/src/main/java/com/dida/hot_user/HotUserViewModel.kt
+++ b/feature/hot-user/src/main/java/com/dida/hot_user/HotUserViewModel.kt
@@ -28,7 +28,7 @@ class HotUserViewModel @Inject constructor(
     private val _navigationEvent: MutableSharedFlow<HotUserNavigationAction> = MutableSharedFlow<HotUserNavigationAction>()
     val navigationEvent: SharedFlow<HotUserNavigationAction> = _navigationEvent.asSharedFlow()
 
-    var hotUserState: Flow<PagingData<HotUser>> = createHotUserPager(hotUserAPI = hotUserAPI).flow.cachedIn(baseViewModelScope)
+    val hotUserState: Flow<PagingData<HotUser>> = createHotUserPager(hotUserAPI = hotUserAPI).flow.cachedIn(baseViewModelScope)
 
     override fun onUserClicked(userId: Long) {
         baseViewModelScope.launch {

--- a/feature/recent-nft/src/main/java/com/dida/recent_nft/RecentNftViewModel.kt
+++ b/feature/recent-nft/src/main/java/com/dida/recent_nft/RecentNftViewModel.kt
@@ -29,7 +29,7 @@ class RecentNftViewModel @Inject constructor(
     private val _navigationEvent: MutableSharedFlow<RecentNftNavigationAction> = MutableSharedFlow<RecentNftNavigationAction>()
     val navigationEvent: SharedFlow<RecentNftNavigationAction> = _navigationEvent.asSharedFlow()
 
-    var cardsState: Flow<PagingData<UserNft>> = createCardPager(recentCardAPI = recentCardAPI).flow.cachedIn(baseViewModelScope)
+    val cardsState: Flow<PagingData<UserNft>> = createCardPager(recentCardAPI = recentCardAPI).flow.cachedIn(baseViewModelScope)
 
     override fun onNftItemClicked(nftId: Long) {
         baseViewModelScope.launch {

--- a/presentation/src/main/java/com/dida/android/presentation/views/CommunityFragment.kt
+++ b/presentation/src/main/java/com/dida/android/presentation/views/CommunityFragment.kt
@@ -51,7 +51,7 @@ class CommunityFragment : BaseFragment<FragmentCommunityBinding, CommunityViewMo
         viewLifecycleOwner.lifecycleScope.launch {
             launch {
                 viewModel.postsState.collectLatest {
-                    communityPagingAdapter.submitData(viewLifecycleOwner.lifecycle, it)
+                    communityPagingAdapter.submitData(it)
                 }
             }
 


### PR DESCRIPTION
n번째 페이지에서 좋아요 누르면 불러온 모든 데이터들이 사라지고 1번째 페이지만 남아있던 현상