### PR TITLE
[DIDA] DIDA API 추가 리팩토링 목록

### DIFF
--- a/data/src/main/java/com/dida/data/main/DidaApi.kt
+++ b/data/src/main/java/com/dida/data/main/DidaApi.kt
@@ -6,6 +6,7 @@ import com.dida.data.model.additional.PostMakePictureResponse
 import com.dida.data.model.additional.PostReportRequest
 import com.dida.data.model.dex.GetMemberSwapResponse
 import com.dida.data.model.dex.GetTransactionInfoResponse
+import com.dida.data.model.dex.GetTransactionsResponse
 import com.dida.data.model.login.GetCommonWalletResponse
 import com.dida.data.model.login.GetEmailAuthResponse
 import com.dida.data.model.login.PatchMemberDeviceRequest
@@ -188,16 +189,26 @@ interface DidaApi {
     @GET("/common/nft/{nftId}")
     suspend fun getNftDetail(nftId: Long): GetNftResponse
 
-    // 전체 거래 내역
+    // 전체 거래 내역 보기
     @GET("/member/transaction")
     suspend fun getTransactionInfos(
         @Query("page") page: Int,
         @Query("size") size: Int,
     ): GetTransactionInfoResponse
 
-    // TODO : 판매 내역 확인하기 API 추가
+    // 판매 내역 보기
+    @GET("/member/transaction/sale")
+    suspend fun getSaleTransactionInfos(
+        @Query("page") page: Int,
+        @Query("size") size: Int,
+    ): GetTransactionsResponse
 
-    // TODO : 구매 내역 확인하기 API 추가
+    // 구매 내역 보기
+    @GET("/member/transaction/purchase")
+    suspend fun getPurchaseTransactionInfos(
+        @Query("page") page: Int,
+        @Query("size") size: Int,
+    ): GetTransactionsResponse
 
     /**
      * 메인 화면

--- a/data/src/main/java/com/dida/data/main/DidaApi.kt
+++ b/data/src/main/java/com/dida/data/main/DidaApi.kt
@@ -15,6 +15,7 @@ import com.dida.data.model.login.PostLoginResponse
 import com.dida.data.model.login.PostNicknameRequest
 import com.dida.data.model.login.PostNicknameResponse
 import com.dida.data.model.login.PostUserRequest
+import com.dida.data.model.main.GetMainResponse
 import com.dida.data.model.main.GetRecentNftsResponse
 import com.dida.data.model.market.GetNftResponse
 import com.dida.data.model.profile.GetCommonFollowResponse
@@ -214,7 +215,10 @@ interface DidaApi {
      * 메인 화면
      **/
 
-    // TODO : 메인화면(Sold Out 제외) API 추가
+    // 메인 화면(Sold Out 제외)
+    @GET("/main")
+    suspend fun getMain(): GetMainResponse
+
 
     // TODO : 메인 화면 Sold Out 조회 API 추가
 

--- a/data/src/main/java/com/dida/data/main/DidaApi.kt
+++ b/data/src/main/java/com/dida/data/main/DidaApi.kt
@@ -5,6 +5,7 @@ import com.dida.data.model.additional.PostMakePictureRequest
 import com.dida.data.model.additional.PostMakePictureResponse
 import com.dida.data.model.additional.PostReportRequest
 import com.dida.data.model.dex.GetMemberSwapResponse
+import com.dida.data.model.dex.GetTransactionInfoResponse
 import com.dida.data.model.login.GetCommonWalletResponse
 import com.dida.data.model.login.GetEmailAuthResponse
 import com.dida.data.model.login.PatchMemberDeviceRequest
@@ -187,7 +188,12 @@ interface DidaApi {
     @GET("/common/nft/{nftId}")
     suspend fun getNftDetail(nftId: Long): GetNftResponse
 
-    // TODO : 전체 거래내역 보기 API 추가
+    // 전체 거래 내역
+    @GET("/member/transaction")
+    suspend fun getTransactionInfos(
+        @Query("page") page: Int,
+        @Query("size") size: Int,
+    ): GetTransactionInfoResponse
 
     // TODO : 판매 내역 확인하기 API 추가
 

--- a/data/src/main/java/com/dida/data/main/DidaApi.kt
+++ b/data/src/main/java/com/dida/data/main/DidaApi.kt
@@ -327,7 +327,12 @@ interface DidaApi {
         @Query("size") size: Int,
     ): GetOwnNftsResponse
 
-    // TODO : 내가 좋아요한 NFT 목록 조회 API 추가
+    // 내가 좋아요한 NFT 목록
+    @GET("/common/nft/like")
+    suspend fun getLikedNfts(
+        @Query("page") page: Int,
+        @Query("size") size: Int,
+    ): GetOwnNftsResponse
 
     /**
      * 추가 기능

--- a/data/src/main/java/com/dida/data/main/DidaApi.kt
+++ b/data/src/main/java/com/dida/data/main/DidaApi.kt
@@ -17,6 +17,7 @@ import com.dida.data.model.login.PostNicknameResponse
 import com.dida.data.model.login.PostUserRequest
 import com.dida.data.model.main.GetMainResponse
 import com.dida.data.model.main.GetRecentNftsResponse
+import com.dida.data.model.main.GetSoldOutResponse
 import com.dida.data.model.market.GetNftResponse
 import com.dida.data.model.profile.GetCommonFollowResponse
 import com.dida.data.model.profile.GetCommonProfileNftResponse
@@ -219,8 +220,11 @@ interface DidaApi {
     @GET("/main")
     suspend fun getMain(): GetMainResponse
 
-
-    // TODO : 메인 화면 Sold Out 조회 API 추가
+    // 메인 화면 Sold Out
+    @GET("/main/sold-out")
+    suspend fun getSoldOut(
+        @Query("range") range: Int
+    ): GetSoldOutResponse
 
     // TODO : Sold Out 더보기 API 추가
 

--- a/data/src/main/java/com/dida/data/main/DidaApi.kt
+++ b/data/src/main/java/com/dida/data/main/DidaApi.kt
@@ -15,8 +15,10 @@ import com.dida.data.model.login.PostLoginResponse
 import com.dida.data.model.login.PostNicknameRequest
 import com.dida.data.model.login.PostNicknameResponse
 import com.dida.data.model.login.PostUserRequest
+import com.dida.data.model.main.GetHotSellerPageResponse
 import com.dida.data.model.main.GetMainResponse
 import com.dida.data.model.main.GetRecentNftsResponse
+import com.dida.data.model.main.GetSoldOutPageResponse
 import com.dida.data.model.main.GetSoldOutResponse
 import com.dida.data.model.market.GetNftResponse
 import com.dida.data.model.profile.GetCommonFollowResponse
@@ -226,9 +228,20 @@ interface DidaApi {
         @Query("range") range: Int
     ): GetSoldOutResponse
 
-    // TODO : Sold Out 더보기 API 추가
+    // Sold Out 더보기
+    @GET("/sold-outs")
+    suspend fun getSoldOutPage(
+        @Query("range") range: Int,
+        @Query("page") page: Int,
+        @Query("size") size: Int,
+    ): GetSoldOutPageResponse
 
-    // TODO : Hot Seller 더보기 API 추가
+    // Hot Seller 더보기
+    @GET("/hot-sellers")
+    suspend fun getHotSellerPage(
+        @Query("page") page: Int,
+        @Query("size") size: Int,
+    ): GetHotSellerPageResponse
 
     // 최신 NFT 더보기
     @GET("/recent-nfts")
@@ -237,7 +250,12 @@ interface DidaApi {
         @Query("size") size: Int,
     ): GetRecentNftsResponse
 
-    // TODO : 활발한 활동 더보기 API 추가
+    // 활발한 활동 더보기
+    @GET("/hot-members")
+    suspend fun getHotMemberPage(
+        @Query("page") page: Int,
+        @Query("size") size: Int,
+    ): GetHotSellerPageResponse
 
     /**
      * SNS 기능

--- a/data/src/main/java/com/dida/data/main/MainRepositoryImpl.kt
+++ b/data/src/main/java/com/dida/data/main/MainRepositoryImpl.kt
@@ -31,6 +31,7 @@ import com.dida.domain.main.model.Comment
 import com.dida.domain.main.model.CommonFollow
 import com.dida.domain.main.model.DealingHistory
 import com.dida.domain.main.model.HotPost
+import com.dida.domain.main.model.HotSellerPage
 import com.dida.domain.main.model.LoginToken
 import com.dida.domain.main.model.Main
 import com.dida.domain.main.model.MemberProfile
@@ -178,8 +179,20 @@ class MainRepositoryImpl @Inject constructor(
         return handleApi { didaApi.getSoldOut(range).toDomain() }
     }
 
+    override suspend fun soldOutPage(range: Int, page: Int, size: Int): NetworkResult<Contents<SoldOut>> {
+        return handleApi { didaApi.getSoldOutPage(range, page, size).toDomain() }
+    }
+
     override suspend fun recentNfts(page: Int, size: Int): NetworkResult<Contents<RecentNft>> {
         return handleApi { didaApi.getRecentNfts(page, size).toDomain() }
+    }
+
+    override suspend fun hotSellerPage(page: Int, size: Int): NetworkResult<Contents<HotSellerPage>> {
+        return handleApi { didaApi.getHotSellerPage(page, size).toDomain() }
+    }
+
+    override suspend fun hotMemberPage(page: Int, size: Int): NetworkResult<Contents<HotSellerPage>> {
+        return handleApi { didaApi.getHotMemberPage(page, size).toDomain() }
     }
 
     override suspend fun writePost(nftId: Long, title: String, content: String): NetworkResult<Unit> {

--- a/data/src/main/java/com/dida/data/main/MainRepositoryImpl.kt
+++ b/data/src/main/java/com/dida/data/main/MainRepositoryImpl.kt
@@ -40,6 +40,7 @@ import com.dida.domain.main.model.OwnNft
 import com.dida.domain.main.model.Post
 import com.dida.domain.main.model.RecentNft
 import com.dida.domain.main.model.Report
+import com.dida.domain.main.model.SoldOut
 import com.dida.domain.main.model.Swap
 import com.dida.domain.main.model.TransactionInfo
 import okhttp3.MultipartBody
@@ -171,6 +172,10 @@ class MainRepositoryImpl @Inject constructor(
 
     override suspend fun main(): NetworkResult<Main> {
         return handleApi { didaApi.getMain().toDomain() }
+    }
+
+    override suspend fun soldOut(range: Int): NetworkResult<SoldOut> {
+        return handleApi { didaApi.getSoldOut(range).toDomain() }
     }
 
     override suspend fun recentNfts(page: Int, size: Int): NetworkResult<Contents<RecentNft>> {

--- a/data/src/main/java/com/dida/data/main/MainRepositoryImpl.kt
+++ b/data/src/main/java/com/dida/data/main/MainRepositoryImpl.kt
@@ -32,6 +32,7 @@ import com.dida.domain.main.model.CommonFollow
 import com.dida.domain.main.model.DealingHistory
 import com.dida.domain.main.model.HotPost
 import com.dida.domain.main.model.LoginToken
+import com.dida.domain.main.model.Main
 import com.dida.domain.main.model.MemberProfile
 import com.dida.domain.main.model.MemberWallet
 import com.dida.domain.main.model.Nft
@@ -166,6 +167,10 @@ class MainRepositoryImpl @Inject constructor(
 
     override suspend fun purchaseTransactionInfos(page: Int, size: Int): NetworkResult<Contents<DealingHistory>> {
         return handleApi { didaApi.getPurchaseTransactionInfos(page, size).toDomain() }
+    }
+
+    override suspend fun main(): NetworkResult<Main> {
+        return handleApi { didaApi.getMain().toDomain() }
     }
 
     override suspend fun recentNfts(page: Int, size: Int): NetworkResult<Contents<RecentNft>> {

--- a/data/src/main/java/com/dida/data/main/MainRepositoryImpl.kt
+++ b/data/src/main/java/com/dida/data/main/MainRepositoryImpl.kt
@@ -242,6 +242,10 @@ class MainRepositoryImpl @Inject constructor(
         return handleApi { didaApi.getOwnNfts(page, size).toDomain() }
     }
 
+    override suspend fun likedNfts(page: Int, size: Int): NetworkResult<Contents<OwnNft>> {
+        return handleApi { didaApi.getLikedNfts(page, size).toDomain() }
+    }
+
     override suspend fun block(type: Block, blockId: Long): NetworkResult<Unit> {
         return when (type) {
             Block.NFT -> handleApi { didaApi.blockNft(blockId) }

--- a/data/src/main/java/com/dida/data/main/MainRepositoryImpl.kt
+++ b/data/src/main/java/com/dida/data/main/MainRepositoryImpl.kt
@@ -39,6 +39,7 @@ import com.dida.domain.main.model.Post
 import com.dida.domain.main.model.RecentNft
 import com.dida.domain.main.model.Report
 import com.dida.domain.main.model.Swap
+import com.dida.domain.main.model.TransactionInfo
 import okhttp3.MultipartBody
 import javax.inject.Inject
 import javax.inject.Named
@@ -152,6 +153,10 @@ class MainRepositoryImpl @Inject constructor(
 
     override suspend fun nftDetail(nftId: Long): NetworkResult<Nft> {
         return handleApi { didaApi.getNftDetail(nftId).toDomain() }
+    }
+
+    override suspend fun transactionInfos(page: Int, size: Int): NetworkResult<Contents<TransactionInfo>> {
+        return handleApi { didaApi.getTransactionInfos(page, size).toDomain() }
     }
 
     override suspend fun recentNfts(page: Int, size: Int): NetworkResult<Contents<RecentNft>> {

--- a/data/src/main/java/com/dida/data/main/MainRepositoryImpl.kt
+++ b/data/src/main/java/com/dida/data/main/MainRepositoryImpl.kt
@@ -29,6 +29,7 @@ import com.dida.domain.main.model.Alarm
 import com.dida.domain.main.model.Block
 import com.dida.domain.main.model.Comment
 import com.dida.domain.main.model.CommonFollow
+import com.dida.domain.main.model.DealingHistory
 import com.dida.domain.main.model.HotPost
 import com.dida.domain.main.model.LoginToken
 import com.dida.domain.main.model.MemberProfile
@@ -157,6 +158,14 @@ class MainRepositoryImpl @Inject constructor(
 
     override suspend fun transactionInfos(page: Int, size: Int): NetworkResult<Contents<TransactionInfo>> {
         return handleApi { didaApi.getTransactionInfos(page, size).toDomain() }
+    }
+
+    override suspend fun saleTransactionInfos(page: Int, size: Int): NetworkResult<Contents<DealingHistory>> {
+        return handleApi { didaApi.getSaleTransactionInfos(page, size).toDomain() }
+    }
+
+    override suspend fun purchaseTransactionInfos(page: Int, size: Int): NetworkResult<Contents<DealingHistory>> {
+        return handleApi { didaApi.getPurchaseTransactionInfos(page, size).toDomain() }
     }
 
     override suspend fun recentNfts(page: Int, size: Int): NetworkResult<Contents<RecentNft>> {

--- a/data/src/main/java/com/dida/data/model/dex/DexMapper.kt
+++ b/data/src/main/java/com/dida/data/model/dex/DexMapper.kt
@@ -2,10 +2,20 @@ package com.dida.data.model.dex
 
 import com.dida.domain.Contents
 import com.dida.domain.main.model.Swap
+import com.dida.domain.main.model.TransactionInfo
 
 fun GetMemberSwapResponse.toDomain(): Contents<Swap> {
     return Contents(
-        page = pageSize,
+        page = page,
+        pageSize = pageSize,
+        hasNext = hasNext,
+        content = response
+    )
+}
+
+fun GetTransactionInfoResponse.toDomain(): Contents<TransactionInfo> {
+    return Contents(
+        page = page,
         pageSize = pageSize,
         hasNext = hasNext,
         content = response

--- a/data/src/main/java/com/dida/data/model/dex/DexMapper.kt
+++ b/data/src/main/java/com/dida/data/model/dex/DexMapper.kt
@@ -1,6 +1,7 @@
 package com.dida.data.model.dex
 
 import com.dida.domain.Contents
+import com.dida.domain.main.model.DealingHistory
 import com.dida.domain.main.model.Swap
 import com.dida.domain.main.model.TransactionInfo
 
@@ -14,6 +15,15 @@ fun GetMemberSwapResponse.toDomain(): Contents<Swap> {
 }
 
 fun GetTransactionInfoResponse.toDomain(): Contents<TransactionInfo> {
+    return Contents(
+        page = page,
+        pageSize = pageSize,
+        hasNext = hasNext,
+        content = response
+    )
+}
+
+fun GetTransactionsResponse.toDomain(): Contents<DealingHistory> {
     return Contents(
         page = page,
         pageSize = pageSize,

--- a/data/src/main/java/com/dida/data/model/dex/GetTransactionInfoResponse.kt
+++ b/data/src/main/java/com/dida/data/model/dex/GetTransactionInfoResponse.kt
@@ -1,0 +1,11 @@
+package com.dida.data.model.dex
+
+import com.dida.domain.main.model.TransactionInfo
+import com.google.gson.annotations.SerializedName
+
+data class GetTransactionInfoResponse(
+    @SerializedName("page") val page: Int,
+    @SerializedName("pageSize") val pageSize: Int,
+    @SerializedName("hasNext") val hasNext: Boolean,
+    @SerializedName("response") val response: List<TransactionInfo>,
+)

--- a/data/src/main/java/com/dida/data/model/dex/GetTransactionsResponse.kt
+++ b/data/src/main/java/com/dida/data/model/dex/GetTransactionsResponse.kt
@@ -1,0 +1,12 @@
+package com.dida.data.model.dex
+
+import com.dida.domain.main.model.DealingHistory
+import com.dida.domain.main.model.TransactionInfo
+import com.google.gson.annotations.SerializedName
+
+data class GetTransactionsResponse(
+    @SerializedName("page") val page: Int,
+    @SerializedName("pageSize") val pageSize: Int,
+    @SerializedName("hasNext") val hasNext: Boolean,
+    @SerializedName("response") val response: List<DealingHistory>,
+)

--- a/data/src/main/java/com/dida/data/model/main/GetHotSellerPageResponse.kt
+++ b/data/src/main/java/com/dida/data/model/main/GetHotSellerPageResponse.kt
@@ -1,0 +1,11 @@
+package com.dida.data.model.main
+
+import com.dida.domain.main.model.HotSellerPage
+import com.google.gson.annotations.SerializedName
+
+data class GetHotSellerPageResponse(
+    @SerializedName("page") val page: Int,
+    @SerializedName("pageSize") val pageSize: Int,
+    @SerializedName("hasNext") val hasNext: Boolean,
+    @SerializedName("response") val response: List<HotSellerPage>,
+)

--- a/data/src/main/java/com/dida/data/model/main/GetMainResponse.kt
+++ b/data/src/main/java/com/dida/data/model/main/GetMainResponse.kt
@@ -1,0 +1,14 @@
+package com.dida.data.model.main
+
+import com.dida.domain.main.model.HotItem
+import com.dida.domain.main.model.HotMember
+import com.dida.domain.main.model.HotSeller
+import com.dida.domain.main.model.RecentNft
+import com.google.gson.annotations.SerializedName
+
+data class GetMainResponse(
+    @SerializedName("getHotItems") val getHotItems: List<HotItem>,
+    @SerializedName("getHotSellers") val getHotSellers: List<HotSeller>,
+    @SerializedName("getRecentNfts") val getRecentNfts: List<RecentNft>,
+    @SerializedName("getHotMembers") val getHotMembers: List<HotMember>,
+)

--- a/data/src/main/java/com/dida/data/model/main/GetSoldOutPageResponse.kt
+++ b/data/src/main/java/com/dida/data/model/main/GetSoldOutPageResponse.kt
@@ -1,0 +1,11 @@
+package com.dida.data.model.main
+
+import com.dida.domain.main.model.SoldOut
+import com.google.gson.annotations.SerializedName
+
+data class GetSoldOutPageResponse(
+    @SerializedName("page") val page: Int,
+    @SerializedName("pageSize") val pageSize: Int,
+    @SerializedName("hasNext") val hasNext: Boolean,
+    @SerializedName("response") val response: List<SoldOut>,
+)

--- a/data/src/main/java/com/dida/data/model/main/GetSoldOutResponse.kt
+++ b/data/src/main/java/com/dida/data/model/main/GetSoldOutResponse.kt
@@ -1,0 +1,10 @@
+package com.dida.data.model.main
+
+import com.dida.domain.main.model.MemberInfo
+import com.dida.domain.main.model.NftInfo
+import com.google.gson.annotations.SerializedName
+
+data class GetSoldOutResponse(
+    @SerializedName("nftInfo") val nftInfo: List<NftInfo>,
+    @SerializedName("memberInfo") val memberInfo: List<MemberInfo>,
+)

--- a/data/src/main/java/com/dida/data/model/main/MainMapper.kt
+++ b/data/src/main/java/com/dida/data/model/main/MainMapper.kt
@@ -1,6 +1,7 @@
 package com.dida.data.model.main
 
 import com.dida.domain.Contents
+import com.dida.domain.main.model.Main
 import com.dida.domain.main.model.RecentNft
 import com.dida.domain.main.model.Swap
 
@@ -11,4 +12,8 @@ fun GetRecentNftsResponse.toDomain(): Contents<RecentNft> {
         hasNext = hasNext,
         content = response
     )
+}
+
+fun GetMainResponse.toDomain(): Main {
+    return Main(getHotItems, getHotSellers, getRecentNfts, getHotMembers)
 }

--- a/data/src/main/java/com/dida/data/model/main/MainMapper.kt
+++ b/data/src/main/java/com/dida/data/model/main/MainMapper.kt
@@ -1,10 +1,10 @@
 package com.dida.data.model.main
 
 import com.dida.domain.Contents
+import com.dida.domain.main.model.HotSellerPage
 import com.dida.domain.main.model.Main
 import com.dida.domain.main.model.RecentNft
 import com.dida.domain.main.model.SoldOut
-import com.dida.domain.main.model.Swap
 
 fun GetRecentNftsResponse.toDomain(): Contents<RecentNft> {
     return Contents(
@@ -22,3 +22,22 @@ fun GetMainResponse.toDomain(): Main {
 fun GetSoldOutResponse.toDomain(): SoldOut {
     return SoldOut(nftInfo, memberInfo)
 }
+
+fun GetSoldOutPageResponse.toDomain(): Contents<SoldOut> {
+    return Contents(
+        page = page,
+        pageSize = pageSize,
+        hasNext = hasNext,
+        content = response
+    )
+}
+
+fun GetHotSellerPageResponse.toDomain(): Contents<HotSellerPage> {
+    return Contents(
+        page = page,
+        pageSize = pageSize,
+        hasNext = hasNext,
+        content = response
+    )
+}
+

--- a/data/src/main/java/com/dida/data/model/main/MainMapper.kt
+++ b/data/src/main/java/com/dida/data/model/main/MainMapper.kt
@@ -3,6 +3,7 @@ package com.dida.data.model.main
 import com.dida.domain.Contents
 import com.dida.domain.main.model.Main
 import com.dida.domain.main.model.RecentNft
+import com.dida.domain.main.model.SoldOut
 import com.dida.domain.main.model.Swap
 
 fun GetRecentNftsResponse.toDomain(): Contents<RecentNft> {
@@ -16,4 +17,8 @@ fun GetRecentNftsResponse.toDomain(): Contents<RecentNft> {
 
 fun GetMainResponse.toDomain(): Main {
     return Main(getHotItems, getHotSellers, getRecentNfts, getHotMembers)
+}
+
+fun GetSoldOutResponse.toDomain(): SoldOut {
+    return SoldOut(nftInfo, memberInfo)
 }

--- a/domain/src/main/java/com/dida/domain/main/MainRepository.kt
+++ b/domain/src/main/java/com/dida/domain/main/MainRepository.kt
@@ -9,6 +9,7 @@ import com.dida.domain.main.model.Comment
 import com.dida.domain.main.model.CommonProfile
 import com.dida.domain.main.model.CommonProfileNft
 import com.dida.domain.main.model.CommonFollow
+import com.dida.domain.main.model.DealingHistory
 import com.dida.domain.main.model.HotPost
 import com.dida.domain.main.model.LoginToken
 import com.dida.domain.main.model.MemberProfile
@@ -71,6 +72,10 @@ interface MainRepository {
     suspend fun nftDetail(nftId: Long): NetworkResult<Nft>
 
     suspend fun transactionInfos(page: Int, size: Int): NetworkResult<Contents<TransactionInfo>>
+
+    suspend fun saleTransactionInfos(page: Int, size: Int): NetworkResult<Contents<DealingHistory>>
+
+    suspend fun purchaseTransactionInfos(page: Int, size: Int): NetworkResult<Contents<DealingHistory>>
 
     suspend fun recentNfts(page: Int, size: Int): NetworkResult<Contents<RecentNft>>
 

--- a/domain/src/main/java/com/dida/domain/main/MainRepository.kt
+++ b/domain/src/main/java/com/dida/domain/main/MainRepository.kt
@@ -20,6 +20,7 @@ import com.dida.domain.main.model.OwnNft
 import com.dida.domain.main.model.Post
 import com.dida.domain.main.model.RecentNft
 import com.dida.domain.main.model.Report
+import com.dida.domain.main.model.SoldOut
 import com.dida.domain.main.model.Swap
 import com.dida.domain.main.model.TransactionInfo
 import okhttp3.MultipartBody
@@ -79,6 +80,8 @@ interface MainRepository {
     suspend fun purchaseTransactionInfos(page: Int, size: Int): NetworkResult<Contents<DealingHistory>>
 
     suspend fun main(): NetworkResult<Main>
+
+    suspend fun soldOut(range: Int): NetworkResult<SoldOut>
 
     suspend fun recentNfts(page: Int, size: Int): NetworkResult<Contents<RecentNft>>
 

--- a/domain/src/main/java/com/dida/domain/main/MainRepository.kt
+++ b/domain/src/main/java/com/dida/domain/main/MainRepository.kt
@@ -12,6 +12,7 @@ import com.dida.domain.main.model.CommonFollow
 import com.dida.domain.main.model.DealingHistory
 import com.dida.domain.main.model.HotPost
 import com.dida.domain.main.model.LoginToken
+import com.dida.domain.main.model.Main
 import com.dida.domain.main.model.MemberProfile
 import com.dida.domain.main.model.MemberWallet
 import com.dida.domain.main.model.Nft
@@ -76,6 +77,8 @@ interface MainRepository {
     suspend fun saleTransactionInfos(page: Int, size: Int): NetworkResult<Contents<DealingHistory>>
 
     suspend fun purchaseTransactionInfos(page: Int, size: Int): NetworkResult<Contents<DealingHistory>>
+
+    suspend fun main(): NetworkResult<Main>
 
     suspend fun recentNfts(page: Int, size: Int): NetworkResult<Contents<RecentNft>>
 

--- a/domain/src/main/java/com/dida/domain/main/MainRepository.kt
+++ b/domain/src/main/java/com/dida/domain/main/MainRepository.kt
@@ -10,7 +10,9 @@ import com.dida.domain.main.model.CommonProfile
 import com.dida.domain.main.model.CommonProfileNft
 import com.dida.domain.main.model.CommonFollow
 import com.dida.domain.main.model.DealingHistory
+import com.dida.domain.main.model.HotMember
 import com.dida.domain.main.model.HotPost
+import com.dida.domain.main.model.HotSellerPage
 import com.dida.domain.main.model.LoginToken
 import com.dida.domain.main.model.Main
 import com.dida.domain.main.model.MemberProfile
@@ -83,7 +85,13 @@ interface MainRepository {
 
     suspend fun soldOut(range: Int): NetworkResult<SoldOut>
 
+    suspend fun soldOutPage(range: Int, page: Int, size: Int): NetworkResult<Contents<SoldOut>>
+
     suspend fun recentNfts(page: Int, size: Int): NetworkResult<Contents<RecentNft>>
+
+    suspend fun hotSellerPage(page: Int, size: Int): NetworkResult<Contents<HotSellerPage>>
+
+    suspend fun hotMemberPage(page: Int, size: Int): NetworkResult<Contents<HotSellerPage>>
 
     suspend fun writePost(nftId: Long, title: String, content: String): NetworkResult<Unit>
 

--- a/domain/src/main/java/com/dida/domain/main/MainRepository.kt
+++ b/domain/src/main/java/com/dida/domain/main/MainRepository.kt
@@ -19,6 +19,7 @@ import com.dida.domain.main.model.Post
 import com.dida.domain.main.model.RecentNft
 import com.dida.domain.main.model.Report
 import com.dida.domain.main.model.Swap
+import com.dida.domain.main.model.TransactionInfo
 import okhttp3.MultipartBody
 
 interface MainRepository {
@@ -68,6 +69,8 @@ interface MainRepository {
     suspend fun memberSwap(page: Int, size: Int): NetworkResult<Contents<Swap>>
 
     suspend fun nftDetail(nftId: Long): NetworkResult<Nft>
+
+    suspend fun transactionInfos(page: Int, size: Int): NetworkResult<Contents<TransactionInfo>>
 
     suspend fun recentNfts(page: Int, size: Int): NetworkResult<Contents<RecentNft>>
 

--- a/domain/src/main/java/com/dida/domain/main/MainRepository.kt
+++ b/domain/src/main/java/com/dida/domain/main/MainRepository.kt
@@ -115,6 +115,8 @@ interface MainRepository {
 
     suspend fun ownNfts(page: Int, size: Int): NetworkResult<Contents<OwnNft>>
 
+    suspend fun likedNfts(page: Int, size: Int): NetworkResult<Contents<OwnNft>>
+
     suspend fun block(type: Block, blockId: Long): NetworkResult<Unit>
 
     suspend fun cancelBlock(type: Block, blockId: Long): NetworkResult<Unit>

--- a/domain/src/main/java/com/dida/domain/main/model/HotItem.kt
+++ b/domain/src/main/java/com/dida/domain/main/model/HotItem.kt
@@ -1,0 +1,9 @@
+package com.dida.domain.main.model
+
+data class HotItem(
+    val nftId: Long,
+    val nftImgUrl: String,
+    val nftName: String,
+    val price: String,
+    val likeCount: String
+)

--- a/domain/src/main/java/com/dida/domain/main/model/HotMember.kt
+++ b/domain/src/main/java/com/dida/domain/main/model/HotMember.kt
@@ -1,0 +1,10 @@
+package com.dida.domain.main.model
+
+data class HotMember(
+    val memberId: Long,
+    val memberName: String,
+    val profileUrl: String,
+    val nftCount: Int,
+    val followed: Boolean,
+    val me: Boolean
+)

--- a/domain/src/main/java/com/dida/domain/main/model/HotSeller.kt
+++ b/domain/src/main/java/com/dida/domain/main/model/HotSeller.kt
@@ -1,0 +1,8 @@
+package com.dida.domain.main.model
+
+data class HotSeller(
+    val memberId: Long,
+    val memberName: String,
+    val profileUrl: String,
+    val nftImgUrl: String
+)

--- a/domain/src/main/java/com/dida/domain/main/model/HotSellerPage.kt
+++ b/domain/src/main/java/com/dida/domain/main/model/HotSellerPage.kt
@@ -1,0 +1,15 @@
+package com.dida.domain.main.model
+
+data class HotSellerPage(
+    val memberInfo: HotSellerInfo,
+    val nftImgUrl: List<String>
+)
+
+data class HotSellerInfo(
+    val memberId: Long,
+    val memberName: String,
+    val profileUrl: String,
+    val nftCount: Int,
+    val followed: Boolean,
+    val me: Boolean
+)

--- a/domain/src/main/java/com/dida/domain/main/model/Main.kt
+++ b/domain/src/main/java/com/dida/domain/main/model/Main.kt
@@ -1,0 +1,8 @@
+package com.dida.domain.main.model
+
+data class Main(
+    val getHotItems: List<HotItem>,
+    val getHotSellers: List<HotSeller>,
+    val getRecentNfts: List<RecentNft>,
+    val getHotMembers: List<HotMember>,
+)

--- a/domain/src/main/java/com/dida/domain/main/model/SoldOut.kt
+++ b/domain/src/main/java/com/dida/domain/main/model/SoldOut.kt
@@ -1,0 +1,6 @@
+package com.dida.domain.main.model
+
+data class SoldOut(
+    val nftInfo: List<NftInfo>,
+    val memberInfo: List<MemberInfo>,
+)

--- a/domain/src/main/java/com/dida/domain/main/model/TransactionInfo.kt
+++ b/domain/src/main/java/com/dida/domain/main/model/TransactionInfo.kt
@@ -1,0 +1,14 @@
+package com.dida.domain.main.model
+
+data class TransactionInfo(
+    val dealingHistory: DealingHistory,
+    val purchased: Boolean
+)
+
+data class DealingHistory(
+    val transactionId: Long,
+    val nftId: Long,
+    val nftTitle: String,
+    val nftUrl: String,
+    val price: Float
+)

--- a/domain/src/main/java/com/dida/domain/usecase/HotMemberPageUseCase.kt
+++ b/domain/src/main/java/com/dida/domain/usecase/HotMemberPageUseCase.kt
@@ -1,0 +1,16 @@
+package com.dida.domain.usecase
+
+import com.dida.domain.Contents
+import com.dida.domain.NetworkResult
+import com.dida.domain.main.MainRepository
+import com.dida.domain.main.model.HotSellerPage
+import com.dida.domain.main.model.SoldOut
+import javax.inject.Inject
+
+class HotMemberPageUseCase @Inject constructor(
+    private val repository: MainRepository
+) {
+    suspend operator fun invoke(page: Int, size: Int) : NetworkResult<Contents<HotSellerPage>> {
+        return repository.hotMemberPage(page, size)
+    }
+}

--- a/domain/src/main/java/com/dida/domain/usecase/HotSellerPageUseCase.kt
+++ b/domain/src/main/java/com/dida/domain/usecase/HotSellerPageUseCase.kt
@@ -1,0 +1,16 @@
+package com.dida.domain.usecase
+
+import com.dida.domain.Contents
+import com.dida.domain.NetworkResult
+import com.dida.domain.main.MainRepository
+import com.dida.domain.main.model.HotSellerPage
+import com.dida.domain.main.model.SoldOut
+import javax.inject.Inject
+
+class HotSellerPageUseCase @Inject constructor(
+    private val repository: MainRepository
+) {
+    suspend operator fun invoke(page: Int, size: Int) : NetworkResult<Contents<HotSellerPage>> {
+        return repository.hotSellerPage(page, size)
+    }
+}

--- a/domain/src/main/java/com/dida/domain/usecase/LikedNftsUseCase.kt
+++ b/domain/src/main/java/com/dida/domain/usecase/LikedNftsUseCase.kt
@@ -1,0 +1,16 @@
+package com.dida.domain.usecase
+
+import com.dida.domain.Contents
+import com.dida.domain.NetworkResult
+import com.dida.domain.main.MainRepository
+import com.dida.domain.main.model.LoginToken
+import com.dida.domain.main.model.OwnNft
+import javax.inject.Inject
+
+class LikedNftsUseCase @Inject constructor(
+    private val repository: MainRepository
+) {
+    suspend operator fun invoke(page: Int, size: Int) : NetworkResult<Contents<OwnNft>> {
+        return repository.likedNfts(page, size)
+    }
+}

--- a/domain/src/main/java/com/dida/domain/usecase/MainUseCase.kt
+++ b/domain/src/main/java/com/dida/domain/usecase/MainUseCase.kt
@@ -1,0 +1,14 @@
+package com.dida.domain.usecase
+
+import com.dida.domain.NetworkResult
+import com.dida.domain.main.MainRepository
+import com.dida.domain.main.model.Main
+import javax.inject.Inject
+
+class MainUseCase @Inject constructor(
+    private val repository: MainRepository
+) {
+    suspend operator fun invoke() : NetworkResult<Main> {
+        return repository.main()
+    }
+}

--- a/domain/src/main/java/com/dida/domain/usecase/PurchaseTransactionsUseCase.kt
+++ b/domain/src/main/java/com/dida/domain/usecase/PurchaseTransactionsUseCase.kt
@@ -1,0 +1,18 @@
+package com.dida.domain.usecase
+
+import com.dida.domain.Contents
+import com.dida.domain.NetworkResult
+import com.dida.domain.main.MainRepository
+import com.dida.domain.main.model.DealingHistory
+import com.dida.domain.main.model.LoginToken
+import com.dida.domain.main.model.MemberProfile
+import com.dida.domain.main.model.TransactionInfo
+import javax.inject.Inject
+
+class PurchaseTransactionsUseCase @Inject constructor(
+    private val repository: MainRepository
+) {
+    suspend operator fun invoke(page: Int, size: Int) : NetworkResult<Contents<DealingHistory>> {
+        return repository.purchaseTransactionInfos(page, size)
+    }
+}

--- a/domain/src/main/java/com/dida/domain/usecase/SaleTransactionsUseCase.kt
+++ b/domain/src/main/java/com/dida/domain/usecase/SaleTransactionsUseCase.kt
@@ -1,0 +1,18 @@
+package com.dida.domain.usecase
+
+import com.dida.domain.Contents
+import com.dida.domain.NetworkResult
+import com.dida.domain.main.MainRepository
+import com.dida.domain.main.model.DealingHistory
+import com.dida.domain.main.model.LoginToken
+import com.dida.domain.main.model.MemberProfile
+import com.dida.domain.main.model.TransactionInfo
+import javax.inject.Inject
+
+class SaleTransactionsUseCase @Inject constructor(
+    private val repository: MainRepository
+) {
+    suspend operator fun invoke(page: Int, size: Int) : NetworkResult<Contents<DealingHistory>> {
+        return repository.saleTransactionInfos(page, size)
+    }
+}

--- a/domain/src/main/java/com/dida/domain/usecase/SoldOutPageUseCase.kt
+++ b/domain/src/main/java/com/dida/domain/usecase/SoldOutPageUseCase.kt
@@ -1,0 +1,15 @@
+package com.dida.domain.usecase
+
+import com.dida.domain.Contents
+import com.dida.domain.NetworkResult
+import com.dida.domain.main.MainRepository
+import com.dida.domain.main.model.SoldOut
+import javax.inject.Inject
+
+class SoldOutPageUseCase @Inject constructor(
+    private val repository: MainRepository
+) {
+    suspend operator fun invoke(range: Int, page: Int, size: Int) : NetworkResult<Contents<SoldOut>> {
+        return repository.soldOutPage(range, page, size)
+    }
+}

--- a/domain/src/main/java/com/dida/domain/usecase/SoldOutUseCase.kt
+++ b/domain/src/main/java/com/dida/domain/usecase/SoldOutUseCase.kt
@@ -1,0 +1,14 @@
+package com.dida.domain.usecase
+
+import com.dida.domain.NetworkResult
+import com.dida.domain.main.MainRepository
+import com.dida.domain.main.model.SoldOut
+import javax.inject.Inject
+
+class SoldOutUseCase @Inject constructor(
+    private val repository: MainRepository
+) {
+    suspend operator fun invoke(range: Int) : NetworkResult<SoldOut> {
+        return repository.soldOut(range)
+    }
+}

--- a/domain/src/main/java/com/dida/domain/usecase/TransactionInfosUseCase.kt
+++ b/domain/src/main/java/com/dida/domain/usecase/TransactionInfosUseCase.kt
@@ -1,0 +1,17 @@
+package com.dida.domain.usecase
+
+import com.dida.domain.Contents
+import com.dida.domain.NetworkResult
+import com.dida.domain.main.MainRepository
+import com.dida.domain.main.model.LoginToken
+import com.dida.domain.main.model.MemberProfile
+import com.dida.domain.main.model.TransactionInfo
+import javax.inject.Inject
+
+class TransactionInfosUseCase @Inject constructor(
+    private val repository: MainRepository
+) {
+    suspend operator fun invoke(page: Int, size: Int) : NetworkResult<Contents<TransactionInfo>> {
+        return repository.transactionInfos(page, size)
+    }
+}


### PR DESCRIPTION
### 작업 내용
- 기존 v1 API 관련 제거(Data, Domain 만 적용) <- 추후 PR에서 Presentation에 적용된 Response v2로 이전 필요

#### 추가한 API
- TODO : 전체 거래내역 보기 API 추가
- TODO : 판매 내역 확인하기 API 추가
- TODO : 구매 내역 확인하기 API 추가
- TODO : 메인화면(Sold Out 제외) API 추가
- TODO : 메인 화면 Sold Out 조회 API 추가
- TODO : Sold Out 더보기 API 추가
- TODO : Hot Seller 더보기 API 추가
- TODO : 내가 좋아요한 NFT 목록 조회 API 추가

### 참고
해당 PR은 모든 기능이 v2로 마이그레이션 후에 develop에 머지해야 합니다.

#### 미적용 API
- TODO : NFT 숨김 목록 조회 API 추가
- TODO : 멤버 숨김 목록 조회 API 추가 
