### PR TITLE
[DIDA] DIDA API 추가 리팩토링 목록

### DIFF
--- a/data/src/main/java/com/dida/data/main/DidaApi.kt
+++ b/data/src/main/java/com/dida/data/main/DidaApi.kt
@@ -9,6 +9,7 @@ import com.dida.data.model.dex.GetTransactionInfoResponse
 import com.dida.data.model.dex.GetTransactionsResponse
 import com.dida.data.model.login.GetCommonWalletResponse
 import com.dida.data.model.login.GetEmailAuthResponse
+import com.dida.data.model.login.GetPublicKeyResponse
 import com.dida.data.model.login.PatchMemberDeviceRequest
 import com.dida.data.model.login.PostLoginRequest
 import com.dida.data.model.login.PostLoginResponse
@@ -69,7 +70,9 @@ interface DidaApi {
     @PATCH("/common/refresh")
     suspend fun patchRefreshToken(@Header("refreshToken") request: String): PostLoginResponse
 
-    // TODO : PUBLICK KEY 발급 받기 API 추가
+    // PUBLICK KEY 발급 받기
+    @GET("/common/key")
+    suspend fun getPublicKey(): GetPublicKeyResponse
 
     // 인증 메일 보내기
     @GET("/visitor/auth")

--- a/data/src/main/java/com/dida/data/main/DidaApi.kt
+++ b/data/src/main/java/com/dida/data/main/DidaApi.kt
@@ -4,9 +4,14 @@ import com.dida.data.model.additional.GetAlarmsResponse
 import com.dida.data.model.additional.PostMakePictureRequest
 import com.dida.data.model.additional.PostMakePictureResponse
 import com.dida.data.model.additional.PostReportRequest
+import com.dida.data.model.dex.DeleteSellNftRequest
 import com.dida.data.model.dex.GetMemberSwapResponse
 import com.dida.data.model.dex.GetTransactionInfoResponse
 import com.dida.data.model.dex.GetTransactionsResponse
+import com.dida.data.model.dex.PostBuyNftRequest
+import com.dida.data.model.dex.PostNftRequest
+import com.dida.data.model.dex.PostSellNftRequest
+import com.dida.data.model.dex.PostSwapRequest
 import com.dida.data.model.login.GetCommonWalletResponse
 import com.dida.data.model.login.GetEmailAuthResponse
 import com.dida.data.model.login.GetPublicKeyResponse
@@ -16,6 +21,7 @@ import com.dida.data.model.login.PostLoginResponse
 import com.dida.data.model.login.PostNicknameRequest
 import com.dida.data.model.login.PostNicknameResponse
 import com.dida.data.model.login.PostUserRequest
+import com.dida.data.model.login.PostWalletRequest
 import com.dida.data.model.main.GetHotSellerPageResponse
 import com.dida.data.model.main.GetMainResponse
 import com.dida.data.model.main.GetRecentNftsResponse
@@ -27,6 +33,7 @@ import com.dida.data.model.profile.GetCommonProfileNftResponse
 import com.dida.data.model.profile.GetCommonProfileResponse
 import com.dida.data.model.profile.GetMemberProfileResponse
 import com.dida.data.model.profile.GetMemberWalletResponse
+import com.dida.data.model.profile.PatchMemberPasswordRequest
 import com.dida.data.model.sns.GetOwnNftsResponse
 import com.dida.data.model.profile.PatchProfileDescriptionRequest
 import com.dida.data.model.profile.PatchProfileNicknameRequest
@@ -41,6 +48,7 @@ import okhttp3.MultipartBody
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
+import retrofit2.http.HTTP
 import retrofit2.http.Header
 import retrofit2.http.Multipart
 import retrofit2.http.PATCH
@@ -78,7 +86,9 @@ interface DidaApi {
     @GET("/visitor/auth")
     suspend fun getEmailAuth(): GetEmailAuthResponse
 
-    // TODO : 지갑 발급하기 API 추가
+    // 지갑 발급하기
+    @POST("/visitor/wallet")
+    suspend fun postWallet(@Body body: PostWalletRequest): Unit
 
     // 지갑 여부 확인
     @GET("/common/wallet")
@@ -155,7 +165,9 @@ interface DidaApi {
     @PATCH("/common/nickname")
     suspend fun patchProfileNickname(@Body body: PatchProfileNicknameRequest): Unit
 
-    // TODO : 결제 비밀번호 수정하기 API 추가
+    // 결제 비밀번호 수정하기
+    @PATCH("/member/password")
+    suspend fun patchMemberPassword(@Body body: PatchMemberPasswordRequest): Unit
 
     // 결제 비밀번호 찾기(임시 비밀번호 발급)
     @PATCH("/member/password/tmp")
@@ -165,15 +177,21 @@ interface DidaApi {
      * Dex 및 Nft
      **/
 
-    // TODO : NFT 만들기 API 추가
+    // NFT 만들기
+    @POST("/member/nft")
+    suspend fun postNft(@Body body: PostNftRequest): Unit
 
     // NFT 삭제하기
     @DELETE("/member/nft/{nftId}")
     suspend fun deleteNft(@Path("nftId") nftId: Long): Unit
 
-    // TODO : KLAY → DIDA 스왑 API 추가
+    // KLAY → DIDA 스왑
+    @POST("/member/klay")
+    suspend fun postSwapToDida(@Body body: PostSwapRequest): Unit
 
-    // TODO : DIDA → KLAY 스왑 스왑 API 추가
+    // DIDA → KLAY 스왑
+    @POST("/member/dida")
+    suspend fun postSwapToKlay(@Body body: PostSwapRequest): Unit
 
     // 스왑 내역 확인하기
     @GET("/member/swap")
@@ -186,11 +204,17 @@ interface DidaApi {
 
     // TODO : KLAY 외부 전송하기 API 추가
 
-    // TODO : NFT 판매하기 API 추가
+    // NFT 판매하기
+    @POST("/member/market")
+    suspend fun postSellNft(@Body body: PostSellNftRequest): Unit
 
-    // TODO : NFT 판매 취소하기 API 추가
+    // NFT 판매 취소하기
+    @HTTP(method = "DELETE", path="/member/market", hasBody = true)
+    suspend fun deleteSellNft(@Body body: DeleteSellNftRequest): Unit
 
-    // TODO : NFT 구매하기 API 추가
+    // NFT 구매하기
+    @POST("/member/market/nft")
+    suspend fun postBuyNft(@Body body: PostBuyNftRequest): Unit
 
     // NFT 상세보기
     @GET("/common/nft/{nftId}")

--- a/data/src/main/java/com/dida/data/main/MainRepositoryImpl.kt
+++ b/data/src/main/java/com/dida/data/main/MainRepositoryImpl.kt
@@ -4,14 +4,21 @@ import com.dida.data.api.handleApi
 import com.dida.data.model.additional.PostMakePictureRequest
 import com.dida.data.model.additional.PostReportRequest
 import com.dida.data.model.additional.toDomain
+import com.dida.data.model.dex.DeleteSellNftRequest
+import com.dida.data.model.dex.PostBuyNftRequest
+import com.dida.data.model.dex.PostNftRequest
+import com.dida.data.model.dex.PostSellNftRequest
+import com.dida.data.model.dex.PostSwapRequest
 import com.dida.data.model.dex.toDomain
 import com.dida.data.model.login.PatchMemberDeviceRequest
 import com.dida.data.model.login.PostLoginRequest
 import com.dida.data.model.login.PostNicknameRequest
 import com.dida.data.model.login.PostUserRequest
+import com.dida.data.model.login.PostWalletRequest
 import com.dida.data.model.login.toDomain
 import com.dida.data.model.main.toDomain
 import com.dida.data.model.market.toDomain
+import com.dida.data.model.profile.PatchMemberPasswordRequest
 import com.dida.data.model.profile.PatchProfileDescriptionRequest
 import com.dida.data.model.profile.PatchProfileNicknameRequest
 import com.dida.data.model.profile.toDomain
@@ -297,6 +304,51 @@ class MainRepositoryImpl @Inject constructor(
 
     override suspend fun getPublicKey(): NetworkResult<PublicKey> {
         return handleApi { didaApi.getPublicKey().toDomain() }
+    }
+
+    override suspend fun createWallet(payPwd: String, checkPwd: String): NetworkResult<Unit> {
+        val body = PostWalletRequest(payPwd, checkPwd)
+        return handleApi { didaApi.postWallet(body) }
+    }
+
+    override suspend fun patchPassword(nowPwd: String, changePwd: String): NetworkResult<Unit> {
+        val body = PatchMemberPasswordRequest(nowPwd, changePwd)
+        return handleApi { didaApi.patchMemberPassword(body) }
+    }
+
+    override suspend fun createNft(
+        payPwd: String,
+        title: String,
+        description: String,
+        image: String
+    ): NetworkResult<Unit> {
+        val body = PostNftRequest(payPwd, title, description, image)
+        return handleApi { didaApi.postNft(body) }
+    }
+
+    override suspend fun swapToDida(payPwd: String, coin: Int): NetworkResult<Unit> {
+        val body = PostSwapRequest(payPwd, coin)
+        return handleApi { didaApi.postSwapToDida(body) }
+    }
+
+    override suspend fun swapToKlay(payPwd: String, coin: Int): NetworkResult<Unit> {
+        val body = PostSwapRequest(payPwd, coin)
+        return handleApi { didaApi.postSwapToKlay(body) }
+    }
+
+    override suspend fun sellNft(payPwd: String, nftId: Long, price: Float): NetworkResult<Unit> {
+        val body = PostSellNftRequest(payPwd, nftId, price)
+        return handleApi { didaApi.postSellNft(body) }
+    }
+
+    override suspend fun cancelSellNft(pawPwd: String, marketId: Long): NetworkResult<Unit> {
+        val body = DeleteSellNftRequest(pawPwd, marketId)
+        return handleApi { didaApi.deleteSellNft(body) }
+    }
+
+    override suspend fun buyNft(payPwd: String, marketId: Long): NetworkResult<Unit> {
+        val body = PostBuyNftRequest(payPwd, marketId)
+        return handleApi { didaApi.postBuyNft(body) }
     }
 
 }

--- a/data/src/main/java/com/dida/data/main/MainRepositoryImpl.kt
+++ b/data/src/main/java/com/dida/data/main/MainRepositoryImpl.kt
@@ -39,6 +39,7 @@ import com.dida.domain.main.model.MemberWallet
 import com.dida.domain.main.model.Nft
 import com.dida.domain.main.model.OwnNft
 import com.dida.domain.main.model.Post
+import com.dida.domain.main.model.PublicKey
 import com.dida.domain.main.model.RecentNft
 import com.dida.domain.main.model.Report
 import com.dida.domain.main.model.SoldOut
@@ -292,6 +293,10 @@ class MainRepositoryImpl @Inject constructor(
 
     override suspend fun alarms(page: Int, size: Int): NetworkResult<Contents<Alarm>> {
         return handleApi { didaApi.getAlarms(page, size).toDomain() }
+    }
+
+    override suspend fun getPublicKey(): NetworkResult<PublicKey> {
+        return handleApi { didaApi.getPublicKey().toDomain() }
     }
 
 }

--- a/data/src/main/java/com/dida/data/model/dex/DeleteSellNftRequest.kt
+++ b/data/src/main/java/com/dida/data/model/dex/DeleteSellNftRequest.kt
@@ -1,0 +1,8 @@
+package com.dida.data.model.dex
+
+import com.google.gson.annotations.SerializedName
+
+data class DeleteSellNftRequest(
+    @SerializedName("payPwd") val payPwd: String,
+    @SerializedName("marketId") val marketId: Long,
+)

--- a/data/src/main/java/com/dida/data/model/dex/PostBuyNftRequest.kt
+++ b/data/src/main/java/com/dida/data/model/dex/PostBuyNftRequest.kt
@@ -1,0 +1,8 @@
+package com.dida.data.model.dex
+
+import com.google.gson.annotations.SerializedName
+
+data class PostBuyNftRequest(
+    @SerializedName("payPwd") val payPwd: String,
+    @SerializedName("marketId") val marketId: Long,
+)

--- a/data/src/main/java/com/dida/data/model/dex/PostNftRequest.kt
+++ b/data/src/main/java/com/dida/data/model/dex/PostNftRequest.kt
@@ -1,0 +1,10 @@
+package com.dida.data.model.dex
+
+import com.google.gson.annotations.SerializedName
+
+data class PostNftRequest(
+    @SerializedName("payPwd") val payPwd: String,
+    @SerializedName("title") val title: String,
+    @SerializedName("description") val description: String,
+    @SerializedName("payPwd") val image: String,
+)

--- a/data/src/main/java/com/dida/data/model/dex/PostSellNftRequest.kt
+++ b/data/src/main/java/com/dida/data/model/dex/PostSellNftRequest.kt
@@ -1,0 +1,9 @@
+package com.dida.data.model.dex
+
+import com.google.gson.annotations.SerializedName
+
+data class PostSellNftRequest(
+    @SerializedName("payPwd") val payPwd: String,
+    @SerializedName("nftId") val nftId: Long,
+    @SerializedName("price") val price: Float,
+)

--- a/data/src/main/java/com/dida/data/model/dex/PostSwapRequest.kt
+++ b/data/src/main/java/com/dida/data/model/dex/PostSwapRequest.kt
@@ -1,0 +1,8 @@
+package com.dida.data.model.dex
+
+import com.google.gson.annotations.SerializedName
+
+data class PostSwapRequest(
+    @SerializedName("payPwd") val payPwd: String,
+    @SerializedName("coin") val coin: Int
+)

--- a/data/src/main/java/com/dida/data/model/login/GetPublicKeyResponse.kt
+++ b/data/src/main/java/com/dida/data/model/login/GetPublicKeyResponse.kt
@@ -1,0 +1,7 @@
+package com.dida.data.model.login
+
+import com.google.gson.annotations.SerializedName
+
+data class GetPublicKeyResponse(
+    @SerializedName("publicKey") val publicKey: String
+)

--- a/data/src/main/java/com/dida/data/model/login/LoginMapper.kt
+++ b/data/src/main/java/com/dida/data/model/login/LoginMapper.kt
@@ -1,6 +1,7 @@
 package com.dida.data.model.login
 
 import com.dida.domain.main.model.LoginToken
+import com.dida.domain.main.model.PublicKey
 
 fun PostLoginResponse.toDomain(): LoginToken {
     return LoginToken(
@@ -8,4 +9,8 @@ fun PostLoginResponse.toDomain(): LoginToken {
         accessToken = accessToken,
         refreshToken = refreshToken,
     )
+}
+
+fun GetPublicKeyResponse.toDomain(): PublicKey {
+    return PublicKey(publicKey)
 }

--- a/data/src/main/java/com/dida/data/model/login/PostWalletRequest.kt
+++ b/data/src/main/java/com/dida/data/model/login/PostWalletRequest.kt
@@ -1,0 +1,8 @@
+package com.dida.data.model.login
+
+import com.google.gson.annotations.SerializedName
+
+data class PostWalletRequest(
+    @SerializedName("payPwd") val payPwd: String,
+    @SerializedName("checkPwd") val checkPwd: String,
+)

--- a/data/src/main/java/com/dida/data/model/profile/PatchMemberPasswordRequest.kt
+++ b/data/src/main/java/com/dida/data/model/profile/PatchMemberPasswordRequest.kt
@@ -1,0 +1,8 @@
+package com.dida.data.model.profile
+
+import com.google.gson.annotations.SerializedName
+
+data class PatchMemberPasswordRequest(
+    @SerializedName("nowPwd") val nowPwd: String,
+    @SerializedName("changePwd") val changePwd: String,
+)

--- a/domain/src/main/java/com/dida/domain/klaytn/UploadAssetUseCase.kt
+++ b/domain/src/main/java/com/dida/domain/klaytn/UploadAssetUseCase.kt
@@ -1,12 +1,10 @@
 package com.dida.domain.klaytn
 
 import com.dida.domain.NetworkResult
-import com.dida.domain.klaytn.Asset
-import com.dida.domain.klaytn.KlaytnRepository
 import okhttp3.MultipartBody
 import javax.inject.Inject
 
-class UploadAssetAPI @Inject constructor(
+class UploadAssetUseCase @Inject constructor(
     private val repository: KlaytnRepository
 ){
     suspend operator fun invoke(file: MultipartBody.Part) : NetworkResult<Asset> {

--- a/domain/src/main/java/com/dida/domain/main/MainRepository.kt
+++ b/domain/src/main/java/com/dida/domain/main/MainRepository.kt
@@ -20,6 +20,7 @@ import com.dida.domain.main.model.MemberWallet
 import com.dida.domain.main.model.Nft
 import com.dida.domain.main.model.OwnNft
 import com.dida.domain.main.model.Post
+import com.dida.domain.main.model.PublicKey
 import com.dida.domain.main.model.RecentNft
 import com.dida.domain.main.model.Report
 import com.dida.domain.main.model.SoldOut
@@ -130,5 +131,12 @@ interface MainRepository {
     suspend fun readAlarm(alarmId: Long): NetworkResult<Unit>
 
     suspend fun alarms(page: Int, size: Int): NetworkResult<Contents<Alarm>>
+
+    /**
+     * 암호화 영역
+     **/
+
+    suspend fun getPublicKey(): NetworkResult<PublicKey>
+
 }
 

--- a/domain/src/main/java/com/dida/domain/main/MainRepository.kt
+++ b/domain/src/main/java/com/dida/domain/main/MainRepository.kt
@@ -138,5 +138,21 @@ interface MainRepository {
 
     suspend fun getPublicKey(): NetworkResult<PublicKey>
 
+    suspend fun createWallet(payPwd: String, checkPwd: String): NetworkResult<Unit>
+
+    suspend fun patchPassword(nowPwd: String, changePwd: String): NetworkResult<Unit>
+
+    suspend fun createNft(payPwd: String, title: String, description: String, image: String): NetworkResult<Unit>
+
+    suspend fun swapToDida(payPwd: String, coin: Int): NetworkResult<Unit>
+
+    suspend fun swapToKlay(payPwd: String, coin: Int): NetworkResult<Unit>
+
+    suspend fun sellNft(payPwd: String, nftId: Long, price: Float): NetworkResult<Unit>
+
+    suspend fun cancelSellNft(pawPwd: String, marketId: Long): NetworkResult<Unit>
+
+    suspend fun buyNft(payPwd: String, marketId: Long): NetworkResult<Unit>
+
 }
 

--- a/domain/src/main/java/com/dida/domain/main/model/PublicKey.kt
+++ b/domain/src/main/java/com/dida/domain/main/model/PublicKey.kt
@@ -1,0 +1,5 @@
+package com.dida.domain.main.model
+
+data class PublicKey(
+    val publicKey: String
+)

--- a/domain/src/main/java/com/dida/domain/usecase/BuyNftUseCase.kt
+++ b/domain/src/main/java/com/dida/domain/usecase/BuyNftUseCase.kt
@@ -1,0 +1,13 @@
+package com.dida.domain.usecase
+
+import com.dida.domain.NetworkResult
+import com.dida.domain.main.MainRepository
+import javax.inject.Inject
+
+class BuyNftUseCase @Inject constructor(
+    private val repository: MainRepository
+) {
+    suspend operator fun invoke(payPwd: String, marketId: Long) : NetworkResult<Unit> {
+        return repository.buyNft(payPwd, marketId)
+    }
+}

--- a/domain/src/main/java/com/dida/domain/usecase/CancelSellNftUseCase.kt
+++ b/domain/src/main/java/com/dida/domain/usecase/CancelSellNftUseCase.kt
@@ -1,0 +1,13 @@
+package com.dida.domain.usecase
+
+import com.dida.domain.NetworkResult
+import com.dida.domain.main.MainRepository
+import javax.inject.Inject
+
+class CancelSellNftUseCase @Inject constructor(
+    private val repository: MainRepository
+) {
+    suspend operator fun invoke(payPwd: String, marketId: Long) : NetworkResult<Unit> {
+        return repository.cancelSellNft(payPwd, marketId)
+    }
+}

--- a/domain/src/main/java/com/dida/domain/usecase/CreateNftUseCase.kt
+++ b/domain/src/main/java/com/dida/domain/usecase/CreateNftUseCase.kt
@@ -1,0 +1,13 @@
+package com.dida.domain.usecase
+
+import com.dida.domain.NetworkResult
+import com.dida.domain.main.MainRepository
+import javax.inject.Inject
+
+class CreateNftUseCase @Inject constructor(
+    private val repository: MainRepository
+) {
+    suspend operator fun invoke(payPwd: String, title: String, description: String, image: String) : NetworkResult<Unit> {
+        return repository.createNft(payPwd, title, description, image)
+    }
+}

--- a/domain/src/main/java/com/dida/domain/usecase/CreateWalletUseCase.kt
+++ b/domain/src/main/java/com/dida/domain/usecase/CreateWalletUseCase.kt
@@ -1,0 +1,13 @@
+package com.dida.domain.usecase
+
+import com.dida.domain.NetworkResult
+import com.dida.domain.main.MainRepository
+import javax.inject.Inject
+
+class CreateWalletUseCase @Inject constructor(
+    private val repository: MainRepository
+) {
+    suspend operator fun invoke(payPwd: String, checkPwd: String) : NetworkResult<Unit> {
+        return repository.createWallet(payPwd, checkPwd)
+    }
+}

--- a/domain/src/main/java/com/dida/domain/usecase/PatchPasswordUseCase.kt
+++ b/domain/src/main/java/com/dida/domain/usecase/PatchPasswordUseCase.kt
@@ -1,0 +1,13 @@
+package com.dida.domain.usecase
+
+import com.dida.domain.NetworkResult
+import com.dida.domain.main.MainRepository
+import javax.inject.Inject
+
+class PatchPasswordUseCase @Inject constructor(
+    private val repository: MainRepository
+) {
+    suspend operator fun invoke(nowPwd: String, changePwd: String) : NetworkResult<Unit> {
+        return repository.patchPassword(nowPwd, changePwd)
+    }
+}

--- a/domain/src/main/java/com/dida/domain/usecase/PublicKeyUseCase.kt
+++ b/domain/src/main/java/com/dida/domain/usecase/PublicKeyUseCase.kt
@@ -1,0 +1,14 @@
+package com.dida.domain.usecase
+
+import com.dida.domain.NetworkResult
+import com.dida.domain.main.MainRepository
+import com.dida.domain.main.model.PublicKey
+import javax.inject.Inject
+
+class PublicKeyUseCase @Inject constructor(
+    private val repository: MainRepository
+) {
+    suspend operator fun invoke() : NetworkResult<PublicKey> {
+        return repository.getPublicKey()
+    }
+}

--- a/domain/src/main/java/com/dida/domain/usecase/SellNftUseCase.kt
+++ b/domain/src/main/java/com/dida/domain/usecase/SellNftUseCase.kt
@@ -1,0 +1,13 @@
+package com.dida.domain.usecase
+
+import com.dida.domain.NetworkResult
+import com.dida.domain.main.MainRepository
+import javax.inject.Inject
+
+class SellNftUseCase @Inject constructor(
+    private val repository: MainRepository
+) {
+    suspend operator fun invoke(payPwd: String, nftId: Long, price: Float) : NetworkResult<Unit> {
+        return repository.sellNft(payPwd, nftId, price)
+    }
+}

--- a/domain/src/main/java/com/dida/domain/usecase/SwapToDidaUseCase.kt
+++ b/domain/src/main/java/com/dida/domain/usecase/SwapToDidaUseCase.kt
@@ -1,0 +1,13 @@
+package com.dida.domain.usecase
+
+import com.dida.domain.NetworkResult
+import com.dida.domain.main.MainRepository
+import javax.inject.Inject
+
+class SwapToDidaUseCase @Inject constructor(
+    private val repository: MainRepository
+) {
+    suspend operator fun invoke(payPwd: String, coin: Int) : NetworkResult<Unit> {
+        return repository.swapToDida(payPwd, coin)
+    }
+}

--- a/domain/src/main/java/com/dida/domain/usecase/SwapToKlayUseCase.kt
+++ b/domain/src/main/java/com/dida/domain/usecase/SwapToKlayUseCase.kt
@@ -1,0 +1,13 @@
+package com.dida.domain.usecase
+
+import com.dida.domain.NetworkResult
+import com.dida.domain.main.MainRepository
+import javax.inject.Inject
+
+class SwapToKlayUseCase @Inject constructor(
+    private val repository: MainRepository
+) {
+    suspend operator fun invoke(payPwd: String, coin: Int) : NetworkResult<Unit> {
+        return repository.swapToKlay(payPwd, coin)
+    }
+}

--- a/feature/add/src/main/java/com/dida/add/main/AddViewModel.kt
+++ b/feature/add/src/main/java/com/dida/add/main/AddViewModel.kt
@@ -1,10 +1,9 @@
 package com.dida.add.main
 
 import com.dida.common.base.BaseViewModel
-import com.dida.data.model.NeedToWalletException
 import com.dida.domain.onError
 import com.dida.domain.onSuccess
-import com.dida.domain.usecase.main.WalletExistedAPI
+import com.dida.domain.usecase.CheckWalletUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -14,7 +13,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class AddViewModel @Inject constructor(
-    private val walletExistedAPI: WalletExistedAPI,
+    private val checkWalletUseCase: CheckWalletUseCase
 ) : BaseViewModel() {
 
     private val TAG = "AddViewModel"
@@ -25,14 +24,9 @@ class AddViewModel @Inject constructor(
     fun getWalletExists() {
         baseViewModelScope.launch {
             showLoading()
-            walletExistedAPI()
+            checkWalletUseCase()
                 .onSuccess { _walletExistsState.emit(it) }
-                .onError { e ->
-                    when (e) {
-                        is NeedToWalletException -> _walletExistsState.emit(false)
-                        else -> catchError(e)
-                    }
-                }
+                .onError { e -> catchError(e) }
             dismissLoading()
         }
     }

--- a/feature/add/src/main/java/com/dida/add/purpose/AddPurposeViewModel.kt
+++ b/feature/add/src/main/java/com/dida/add/purpose/AddPurposeViewModel.kt
@@ -4,10 +4,7 @@ import com.dida.common.base.BaseViewModel
 import com.dida.domain.flatMap
 import com.dida.domain.onError
 import com.dida.domain.onSuccess
-import com.dida.domain.klaytn.UploadAssetAPI
-import com.dida.domain.usecase.main.MintNftAPI
-import com.dida.domain.usecase.main.SellNftAPI
-import com.dida.domain.usecase.main.UserProfileAPI
+import com.dida.domain.klaytn.UploadAssetUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
@@ -20,7 +17,7 @@ import javax.inject.Inject
 @HiltViewModel
 class AddPurposeViewModel @Inject constructor(
     private val mintNftAPI: MintNftAPI,
-    private val uploadAssetAPI: UploadAssetAPI,
+    private val uploadAssetUseCase: UploadAssetUseCase,
     private val userProfileAPI: UserProfileAPI,
     private val sellNftAPI: SellNftAPI
 ) : BaseViewModel(), AddPurposeActionHandler {
@@ -93,7 +90,7 @@ class AddPurposeViewModel @Inject constructor(
             val requestFile = file.asRequestBody("image/*".toMediaTypeOrNull())
             val requestBody = MultipartBody.Part.createFormData("file", file.name, requestFile)
 
-            uploadAssetAPI(requestBody)
+            uploadAssetUseCase(requestBody)
                 .onSuccess { }
                 .onError { e -> catchError(e) }
                 .flatMap {


### PR DESCRIPTION
### 작업 내용
- 기존 v1 API 관련 제거(Data, Domain 만 적용) <- 추후 PR에서 Presentation에 적용된 Response v2로 이전 필요

#### 참고
해당 PR은 모든 기능이 v2로 마이그레이션 후에 develop에 머지해야 합니다.
아래 목록의 API 추가 해야 합니다.

### 작용 내용
- TODO : PUBLICK KEY 발급 받기 API 추가
- TODO : 지갑 발급하기 API 추가
- TODO : 결제 비밀번호 수정하기 API 추가
- TODO : NFT 만들기 API 추가
- TODO : KLAY → DIDA 스왑 API 추가
- TODO : DIDA → KLAY 스왑 스왑 API 추가

아래 목록의 API들은 암호화 추가후 적용 예정
#### 암호화 API
- TODO : NFT 외부 전송하기 API 추가
- TODO : KLAY 외부 전송하기 API 추가