### PR TITLE
[DIDA] Paging 로직 수정 > 기존 Compose & 페이징 관련 리스트 업데이트 재대로 안되던 내용들 수정

### DIFF
--- a/feature/compose/src/main/java/com/dida/compose/utils/PagingUtils.kt
+++ b/feature/compose/src/main/java/com/dida/compose/utils/PagingUtils.kt
@@ -1,0 +1,5 @@
+package com.dida.compose.utils
+
+import androidx.compose.foundation.lazy.LazyListState
+
+fun LazyListState.reachEnd() = layoutInfo.visibleItemsInfo.lastOrNull()?.index == layoutInfo.totalItemsCount - 1

--- a/feature/create-community/src/main/java/com/dida/create_community/CreateCommunityViewModel.kt
+++ b/feature/create-community/src/main/java/com/dida/create_community/CreateCommunityViewModel.kt
@@ -70,9 +70,11 @@ class CreateCommunityViewModel @Inject constructor(
             if (!likeNftState.value.hasNext) {
                 return@launch
             }
-            likedNftsUseCase(page = likeNftState.value.page + 1, PAGE_SIZE).onSuccess {
-                _likeNftState.value = it.copy(content = it.content)
-            }
+            likedNftsUseCase(page = likeNftState.value.page + 1, PAGE_SIZE)
+                .onSuccess {
+                    it.content = (likeNftState.value.content.toMutableList() + it.content)
+                    _likeNftState.value = it
+                }.onError { e -> catchError(e) }
         }
     }
 
@@ -81,9 +83,11 @@ class CreateCommunityViewModel @Inject constructor(
             if (!ownNftState.value.hasNext) {
                 return@launch
             }
-            ownNftsUseCase(page = ownNftState.value.page + 1, PAGE_SIZE).onSuccess {
-                _ownNftState.value = it.copy(content = ownNftState.value.content + it.content)
-            }
+            ownNftsUseCase(page = ownNftState.value.page + 1, PAGE_SIZE)
+                .onSuccess {
+                    it.content = (ownNftState.value.content.toMutableList() + it.content)
+                    _ownNftState.value = it
+                }.onError { e -> catchError(e) }
         }
     }
 }

--- a/feature/hot-seller/src/main/java/com/dida/hot_seller/HotSellerViewModel.kt
+++ b/feature/hot-seller/src/main/java/com/dida/hot_seller/HotSellerViewModel.kt
@@ -56,7 +56,9 @@ class HotSellerViewModel @Inject constructor(
             if (!hotSellerState.value.hasNext) return@launch
             showLoading()
             hotSellerPageUseCase.invoke(hotSellerState.value.page + 1, PAGE_SIZE)
-                .onSuccess { _hotSellerState.value = it }
+                .onSuccess {
+                    it.content = (hotSellerState.value.content.toMutableList()) + it.content
+                    _hotSellerState.value = it }
                 .onError { e -> catchError(e) }
             dismissLoading()
         }

--- a/feature/hot-user/src/main/java/com/dida/hot_user/HotUserViewModel.kt
+++ b/feature/hot-user/src/main/java/com/dida/hot_user/HotUserViewModel.kt
@@ -64,7 +64,9 @@ class HotUserViewModel @Inject constructor(
         baseViewModelScope.launch {
             if (!hotMemberState.value.hasNext) return@launch
             hotMemberPageUseCase(page = hotMemberState.value.page + 1, size = PAGE_SIZE)
-                .onSuccess { _hotMemberState.value = it }
+                .onSuccess {
+                    it.content = (hotMemberState.value.content.toMutableList()) + it.content
+                    _hotMemberState.value = it }
                 .onError { e -> catchError(e) }
         }
     }

--- a/feature/recent-nft/src/main/java/com/dida/recent_nft/RecentNftViewModel.kt
+++ b/feature/recent-nft/src/main/java/com/dida/recent_nft/RecentNftViewModel.kt
@@ -80,7 +80,9 @@ class RecentNftViewModel @Inject constructor(
         baseViewModelScope.launch {
             if (!recentNftState.value.hasNext) return@launch
             recentNftsUseCase(recentNftState.value.page + 1, PAGE_SIZE)
-                .onSuccess { _recentNftState.value = it }
+                .onSuccess {
+                    it.content = (recentNftState.value.content.toMutableList() + it.content)
+                    _recentNftState.value = it }
                 .onError { e -> catchError(e) }
         }
     }

--- a/feature/settings/src/main/java/com/dida/settings/hidelist/HideListViewModel.kt
+++ b/feature/settings/src/main/java/com/dida/settings/hidelist/HideListViewModel.kt
@@ -73,9 +73,8 @@ class HideListViewModel @Inject constructor(
             hideNftsUseCase(hideCardState.value.page + 1, PAGE_SIZE)
                 .onSuccess {
                     it.content = (hideCardState.value.content.toMutableList()) + it.content
-                    _hideCardState.emit(it)
-                }
-                .onError { e -> catchError(e) }
+                    _hideCardState.value = it
+                }.onError { e -> catchError(e) }
         }
     }
 }

--- a/feature/sold-out/src/main/java/com/dida/soldout/SoldOutViewModel.kt
+++ b/feature/sold-out/src/main/java/com/dida/soldout/SoldOutViewModel.kt
@@ -64,8 +64,7 @@ class SoldOutViewModel @AssistedInject constructor(
                 .onSuccess {
                     it.content = (soldOutState.value.content.toMutableList()) + it.content
                     _soldOutState.value = it
-                }
-                .onError { e -> catchError(e) }
+                }.onError { e -> catchError(e) }
         }
     }
 

--- a/feature/swap-history/src/main/java/com/dida/swap/history/SwapHistoryViewModel.kt
+++ b/feature/swap-history/src/main/java/com/dida/swap/history/SwapHistoryViewModel.kt
@@ -47,7 +47,8 @@ class SwapHistoryViewModel @Inject constructor(
             if (!swapHistoryState.value.hasNext) return@launch
             memberSwapUseCase(page = swapHistoryState.value.page + 1, size = PAGE_SIZE)
                 .onSuccess {
-                    _swapHistoryState.emit(it)
+                    it.content = (swapHistoryState.value.content.toMutableList() + it.content)
+                    _swapHistoryState.value = it
                     _navigationEvent.emit(SwapHistoryNavigationAction.finishGetSwapHistory)
                 }.onError { e -> catchError(e) }
         }

--- a/feature/user-followed/src/main/java/com/dida/user_followed/UserFollowedViewModel.kt
+++ b/feature/user-followed/src/main/java/com/dida/user_followed/UserFollowedViewModel.kt
@@ -72,8 +72,7 @@ class UserFollowedViewModel @Inject constructor(
                 .onSuccess {
                     it.content = (followerState.value.content.toMutableList()) + it.content
                     _followerState.value = it
-                }
-                .onError { e -> catchError(e) }
+                }.onError { e -> catchError(e) }
         }
     }
 
@@ -84,8 +83,7 @@ class UserFollowedViewModel @Inject constructor(
                 .onSuccess {
                     it.content = (followingState.value.content.toMutableList()) + it.content
                     _followingState.value = it
-                }
-                .onError { e -> catchError(e) }
+                }.onError { e -> catchError(e) }
         }
     }
 

--- a/presentation/src/main/java/com/dida/android/presentation/views/CreateCommunityFragment.kt
+++ b/presentation/src/main/java/com/dida/android/presentation/views/CreateCommunityFragment.kt
@@ -51,6 +51,7 @@ import com.dida.compose.utils.LineDivider
 import com.dida.compose.utils.NoRippleInteractionSource
 import com.dida.compose.utils.VerticalDivider
 import com.dida.compose.utils.clickableSingle
+import com.dida.compose.utils.reachEnd
 import com.dida.create_community.CreateCommunityNavigationAction
 import com.dida.create_community.CreateCommunityViewModel
 import com.dida.create_community.databinding.FragmentCreateCommunityBinding
@@ -202,7 +203,7 @@ class CreateCommunityFragment : BaseFragment<FragmentCreateCommunityBinding, Cre
         val items by viewModel.likeNftState.collectAsStateWithLifecycle()
         val listState = rememberLazyListState()
         val nextPage by remember {
-            derivedStateOf { listState.firstVisibleItemIndex == (items.content.size - 10) }
+            derivedStateOf { listState.reachEnd() }
         }
 
         LaunchedEffect(key1 = nextPage) {
@@ -238,7 +239,7 @@ class CreateCommunityFragment : BaseFragment<FragmentCreateCommunityBinding, Cre
         val items by viewModel.ownNftState.collectAsStateWithLifecycle()
         val listState = rememberLazyListState()
         val nextPage by remember {
-            derivedStateOf { listState.firstVisibleItemIndex == (items.content.size - 10) }
+            derivedStateOf { listState.reachEnd() }
         }
 
         LaunchedEffect(key1 = nextPage) {

--- a/presentation/src/main/java/com/dida/android/presentation/views/HotSellerFragment.kt
+++ b/presentation/src/main/java/com/dida/android/presentation/views/HotSellerFragment.kt
@@ -8,6 +8,7 @@ import com.dida.hot_seller.HotSellerViewModel
 import com.dida.hot_seller.databinding.FragmentHotSellerBinding
 import dagger.hilt.android.AndroidEntryPoint
 
+// TODO : HotSeller 더보기 Ui 완성하기
 @AndroidEntryPoint
 class HotSellerFragment : BaseFragment<FragmentHotSellerBinding, HotSellerViewModel>(com.dida.hot_seller.R.layout.fragment_hot_seller) {
 

--- a/presentation/src/main/java/com/dida/android/presentation/views/SoldOutFragment.kt
+++ b/presentation/src/main/java/com/dida/android/presentation/views/SoldOutFragment.kt
@@ -45,6 +45,7 @@ import com.dida.compose.utils.DidaImage
 import com.dida.compose.utils.HorizontalDivider
 import com.dida.compose.utils.VerticalDivider
 import com.dida.compose.utils.clickableSingle
+import com.dida.compose.utils.reachEnd
 import com.dida.domain.main.model.SoldOut
 import com.dida.soldout.Period
 import com.dida.soldout.SoldOutViewModel
@@ -93,7 +94,7 @@ class SoldOutFragment : BaseFragment<FragmentSoldOutBinding, SoldOutViewModel>(c
                 val items by viewModel.soldOutState.collectAsStateWithLifecycle()
                 val listState = rememberLazyListState()
                 val nextPage by remember {
-                    derivedStateOf { listState.firstVisibleItemIndex == (items.content.size - 10) }
+                    derivedStateOf { listState.reachEnd() }
                 }
 
                 LaunchedEffect(key1 = nextPage) {

--- a/presentation/src/main/java/com/dida/android/presentation/views/UserFollowedFragment.kt
+++ b/presentation/src/main/java/com/dida/android/presentation/views/UserFollowedFragment.kt
@@ -53,6 +53,7 @@ import com.dida.compose.utils.LineDivider
 import com.dida.compose.utils.NoRippleInteractionSource
 import com.dida.compose.utils.VerticalDivider
 import com.dida.compose.utils.clickableSingle
+import com.dida.compose.utils.reachEnd
 import com.dida.domain.main.model.CommonFollow
 import com.dida.domain.main.model.Follow
 import com.dida.user_followed.UserFollowedMessageAction
@@ -198,7 +199,7 @@ class UserFollowedFragment :
         val items by viewModel.followerState.collectAsStateWithLifecycle()
         val listState = rememberLazyListState()
         val nextPage by remember {
-            derivedStateOf { listState.firstVisibleItemIndex == (items.content.size - 10) }
+            derivedStateOf { listState.reachEnd() }
         }
 
         LaunchedEffect(key1 = nextPage) {
@@ -229,7 +230,7 @@ class UserFollowedFragment :
         val items by viewModel.followingState.collectAsStateWithLifecycle()
         val listState = rememberLazyListState()
         val nextPage by remember {
-            derivedStateOf { listState.firstVisibleItemIndex == (items.content.size - 10) }
+            derivedStateOf { listState.reachEnd() }
         }
 
         LaunchedEffect(key1 = nextPage) {


### PR DESCRIPTION
### 작업 내용
1. Compose Paging로직 수정
2. 기존 리스트 업데이트 안되던 현상 수정

### 참고사항
- Compose의 경우 lastVisibleItemIndex를 알수 없으므로 아래와 같이 공통 함수로 뽑아서 사용을 했습니다.
~~~kotlin
// 공통함수
fun LazyListState.reachEnd() = layoutInfo.visibleItemsInfo.lastOrNull()?.index == layoutInfo.totalItemsCount - 1

// 사용
        val nextPage by remember {
            derivedStateOf { listState.reachEnd() }
        }
~~~