### PR TITLE
[DIDA] NFT가격 소수점 자리 포맷 변경

### DIFF
--- a/feature/community-detail/src/main/res/layout/holder_detail_community_header.xml
+++ b/feature/community-detail/src/main/res/layout/holder_detail_community_header.xml
@@ -162,7 +162,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginLeft="8dp"
                     android:fontFamily="@font/pretendard_semibold"
-                    android:text="@{holder.nftInfo.price}"
+                    decimalPrice="@{holder.nftInfo.price}"
                     android:textColor="@color/hots_coin_txt"
                     android:textSize="12dp"
                     app:layout_constraintBottom_toBottomOf="@id/dida_img"

--- a/feature/home/src/main/res/layout/holder_soldout.xml
+++ b/feature/home/src/main/res/layout/holder_soldout.xml
@@ -107,7 +107,7 @@
                 android:layout_marginLeft="8dp"
                 android:ellipsize="end"
                 android:maxLines="1"
-                android:text="@{holderModel.nftInfo.price}"
+                decimalPrice="@{holderModel.nftInfo.price}"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintLeft_toRightOf="@id/soldout_img"
                 app:layout_constraintTop_toTopOf="parent">

--- a/feature/nft-detail/src/main/java/com/dida/nft_detail/DetailNftBindingAdapters.kt
+++ b/feature/nft-detail/src/main/java/com/dida/nft_detail/DetailNftBindingAdapters.kt
@@ -14,6 +14,7 @@ import com.bumptech.glide.Glide
 import com.bumptech.glide.load.resource.bitmap.CenterCrop
 import com.bumptech.glide.load.resource.bitmap.RoundedCorners
 import com.dida.common.util.UiState
+import com.dida.common.util.addPriceDot
 import com.dida.common.util.successOrNull
 import com.dida.domain.main.model.Nft
 import com.dida.nft_detail.bottom.DetailOwnerType
@@ -92,7 +93,19 @@ fun TextView.bindTokenId(uiState: UiState<Nft>) {
 
 @BindingAdapter("NftPrice")
 fun TextView.bindPrice(uiState: UiState<Nft>) {
-    this.text = uiState.successOrNull()?.nftInfo?.price
+    val price = uiState.successOrNull()?.nftInfo?.price
+    if (price.isNullOrEmpty() || price == "NOT SALE" || price == "NO MARKETED") {
+        this.text = "NOT SALE"
+    } else {
+        val roundedValue = (price.toDouble() * 100).toLong() / 100.0
+
+        val formattedValue = if (roundedValue % 1 == 0.0) {
+            String.format("%.0f", roundedValue)
+        } else {
+            String.format("%.2f", roundedValue)
+        }
+        this.text = "${addPriceDot(formattedValue)}"
+    }
 }
 
 @SuppressLint("SetTextI18n")


### PR DESCRIPTION
- 홈화면의 Sold Out 아이템의 가격 소수점 2자리 까지로 표현
- NFT상세페이지 가격 소수점 2자리 까지로 표현
- 커뮤니티 상세페이지 가격 소주점 2자리 까지로 표현