### PR TITLE
[DIDA] 소유권 내역 코드 수정 & 이전 소유 내역내에서만 스크롤 되던 현상 수정

### DIFF
--- a/feature/nft-detail/src/main/java/com/dida/nft_detail/DetailNftNavigationAction.kt
+++ b/feature/nft-detail/src/main/java/com/dida/nft_detail/DetailNftNavigationAction.kt
@@ -14,7 +14,7 @@ sealed class DetailNftNavigationAction {
     class NavigateToUpdate(val postId: Long): DetailNftNavigationAction()
     class NavigateToDelete(val postId: Long): DetailNftNavigationAction()
     class NavigateToOwnerShipHistory(val nftId: Long): DetailNftNavigationAction()
-    class NavigateToCancel(): DetailNftNavigationAction()
+    object NavigateToCancel : DetailNftNavigationAction()
     object NavigateToWritePost: DetailNftNavigationAction()
     class NavigateToImageDetail(val imageUrl: String?, val imageTitle: String?, val imageDescription: String?): DetailNftNavigationAction()
 }

--- a/feature/nft-detail/src/main/java/com/dida/nft_detail/DetailNftViewModel.kt
+++ b/feature/nft-detail/src/main/java/com/dida/nft_detail/DetailNftViewModel.kt
@@ -147,7 +147,7 @@ class DetailNftViewModel @Inject constructor(
                 payPwd = payPwd.encryptWithPublicKey(publicKey.publicKey),
                 marketId = marketIdState.value
             ).onSuccess {
-                _navigationEvent.emit(DetailNftNavigationAction.NavigateToCancel())
+                _navigationEvent.emit(DetailNftNavigationAction.NavigateToCancel)
             }.onError { e -> catchError(e) }
             dismissLoading()
         }

--- a/feature/nft-detail/src/main/res/layout/fragment_detail_nft.xml
+++ b/feature/nft-detail/src/main/res/layout/fragment_detail_nft.xml
@@ -126,38 +126,6 @@
                         app:userNickname="@{vm.detailNftState}"
                         tools:text="user name here" />
 
-                    <androidx.constraintlayout.widget.ConstraintLayout
-                        android:id="@+id/whos_main"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginEnd="16dp"
-                        android:background="@drawable/custom_surface1_radius8"
-                        android:padding="12dp"
-                        app:layout_constraintBottom_toBottomOf="@id/user_img"
-                        app:layout_constraintRight_toRightOf="parent"
-                        app:layout_constraintTop_toTopOf="@id/user_img">
-
-                        <ImageView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_marginStart="8dp"
-                            android:src="@drawable/ic_whos"
-                            app:layout_constraintBottom_toBottomOf="parent"
-                            app:layout_constraintLeft_toRightOf="@id/whos_txt"
-                            app:layout_constraintTop_toTopOf="parent" />
-
-                        <TextView
-                            android:id="@+id/whos_txt"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:fontFamily="@font/pretendard_regular"
-                            android:text="@string/detail_nft_who_text"
-                            android:textColor="@color/white"
-                            android:textSize="12dp"
-                            app:layout_constraintBottom_toBottomOf="parent"
-                            app:layout_constraintLeft_toLeftOf="parent"
-                            app:layout_constraintTop_toTopOf="parent" />
-                    </androidx.constraintlayout.widget.ConstraintLayout>
                 </androidx.constraintlayout.widget.ConstraintLayout>
 
                 <View

--- a/feature/ownership-history/src/main/java/com/dida/ownership_history/OwnerShipHistoryViewModel.kt
+++ b/feature/ownership-history/src/main/java/com/dida/ownership_history/OwnerShipHistoryViewModel.kt
@@ -31,12 +31,11 @@ class OwnerShipHistoryViewModel @Inject constructor(
         nftIdState.value = nftId
     }
 
-    fun getOwnershipHistory(){
+    fun getOwnershipHistory() {
         baseViewModelScope.launch {
             ownershipHistoryUseCase(nftId = nftIdState.value, page = 0, pageSize = PAGE_SIZE)
-                .onSuccess {
-                    _ownershipHistoryState.emit(it)
-                }.onError { e -> catchError(e) }
+                .onSuccess { _ownershipHistoryState.value = it }
+                .onError { e -> catchError(e) }
         }
     }
 

--- a/feature/ownership-history/src/main/java/com/dida/ownership_history/component/OwnershipHistoryItem.kt
+++ b/feature/ownership-history/src/main/java/com/dida/ownership_history/component/OwnershipHistoryItem.kt
@@ -9,41 +9,48 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.dida.common.util.convertyyyyMMdd
 import com.dida.compose.theme.BrandLemon
 import com.dida.compose.theme.DidaTypography
+import com.dida.compose.theme.Surface4
 import com.dida.compose.theme.Surface6
+import com.dida.compose.theme.Surface8
 import com.dida.compose.theme.White
 import com.dida.compose.theme.dpToSp
+import com.dida.compose.utils.LineDivider
 import com.dida.domain.main.model.OwnershipHistory
 
 @Composable
 fun OwnershipHistoryItem(
-    modifier: Modifier,
-    nameColor: Color,
+    modifier: Modifier = Modifier,
+    currentOwner: Boolean,
     item: OwnershipHistory
 ) {
-    Column {
+    val nameColor = if (currentOwner) White else Surface8
+    Column(
+        modifier = modifier
+    ) {
         Row(
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(vertical = 12.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.SpaceBetween,
-            modifier = modifier.fillMaxWidth()
         ) {
             Column {
                 Text(
                     text = convertyyyyMMdd(item.ownerDate),
                     modifier = modifier
                         .padding(),
-                    style = DidaTypography.subtitle2,
+                    style = DidaTypography.caption,
                     fontSize = dpToSp(dp = 14.dp),
                     color = Surface6
                 )
                 Text(
                     text = item.ownerName,
-                    style = DidaTypography.subtitle2,
+                    style = DidaTypography.subtitle1,
                     fontSize = dpToSp(dp = 14.dp),
                     color = nameColor
                 )
@@ -51,10 +58,13 @@ fun OwnershipHistoryItem(
 
             Text(
                 text = "${item.price} dida",
-                style = DidaTypography.subtitle2,
+                style = DidaTypography.subtitle1,
                 fontSize = dpToSp(dp = 14.dp),
                 color = BrandLemon
             )
+        }
+        if (!currentOwner) {
+            LineDivider(Surface4, 1)
         }
     }
 }
@@ -64,7 +74,7 @@ fun OwnershipHistoryItem(
 fun OwnershipHistoryItemPreview() {
     OwnershipHistoryItem(
         modifier = Modifier,
-        nameColor = White,
+        currentOwner = true,
         item = OwnershipHistory("2023-12-08T11:32:11.049677", 2, "서승환", 0.0)
     )
 }

--- a/feature/ownership-history/src/main/java/com/dida/ownership_history/component/OwnershipHistoryItem.kt
+++ b/feature/ownership-history/src/main/java/com/dida/ownership_history/component/OwnershipHistoryItem.kt
@@ -1,16 +1,10 @@
 package com.dida.ownership_history.component
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.material.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -21,23 +15,23 @@ import androidx.compose.ui.unit.dp
 import com.dida.common.util.convertyyyyMMdd
 import com.dida.compose.theme.BrandLemon
 import com.dida.compose.theme.DidaTypography
-import com.dida.compose.theme.Surface4
 import com.dida.compose.theme.Surface6
 import com.dida.compose.theme.White
 import com.dida.compose.theme.dpToSp
-import com.dida.compose.utils.LineDivider
 import com.dida.domain.main.model.OwnershipHistory
 
 @Composable
 fun OwnershipHistoryItem(
     modifier: Modifier,
-    nameColor : Color,
+    nameColor: Color,
     item: OwnershipHistory
 ) {
     Column {
-        Row(verticalAlignment = Alignment.CenterVertically,
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.SpaceBetween,
-            modifier = modifier.fillMaxWidth()) {
+            modifier = modifier.fillMaxWidth()
+        ) {
             Column {
                 Text(
                     text = convertyyyyMMdd(item.ownerDate),
@@ -71,5 +65,6 @@ fun OwnershipHistoryItemPreview() {
     OwnershipHistoryItem(
         modifier = Modifier,
         nameColor = White,
-        item = OwnershipHistory("2023-12-08T11:32:11.049677",2,"서승환",0.0))
+        item = OwnershipHistory("2023-12-08T11:32:11.049677", 2, "서승환", 0.0)
+    )
 }

--- a/feature/ownership-history/src/main/res/values/strings.xml
+++ b/feature/ownership-history/src/main/res/values/strings.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="ownership_history_title">소유권 내역</string>
+    <string name="ownership_current_owner_title">현재 소유자</string>
+    <string name="ownership_before_owner_title">이전 소유 내역</string>
 </resources>

--- a/presentation/src/main/java/com/dida/android/presentation/views/OwnerShipHistoryFragment.kt
+++ b/presentation/src/main/java/com/dida/android/presentation/views/OwnerShipHistoryFragment.kt
@@ -82,29 +82,26 @@ class OwnerShipHistoryFragment : BaseFragment<FragmentOwnershipHistoryBinding, O
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.composeView.apply {
-            binding.composeView.apply {
-                setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
-                setContent {
-                    val ownerShipHistoryList by viewModel.ownershipHistoryState.collectAsStateWithLifecycle()
-                    AppLog.e("haha ${ownerShipHistoryList}")
-                    val listState = rememberLazyListState()
-                    val nextPage by remember {
-                        derivedStateOf { listState.reachEnd() }
-                    }
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                val ownerShipHistoryList by viewModel.ownershipHistoryState.collectAsStateWithLifecycle()
+                val listState = rememberLazyListState()
+                val nextPage by remember {
+                    derivedStateOf { listState.reachEnd() }
+                }
 
-                    LaunchedEffect(key1 = nextPage) {
-                        if (nextPage) viewModel.nextPage()
-                    }
-                    Column{
-                        currentOwnerArea(ownerShipHistoryList)
+                LaunchedEffect(key1 = nextPage) {
+                    if (nextPage) viewModel.nextPage()
+                }
+                Column{
+                    currentOwnerArea(ownerShipHistoryList)
 
-                        //소유권 내역이 하나라면 이전소유내역 비 노출
-                        if(ownerShipHistoryList.content.size > 1){
-                            Spacer(Modifier.size(32.dp))
-                            LineDivider(Surface1,8)
+                    //소유권 내역이 하나라면 이전소유내역 비 노출
+                    if (ownerShipHistoryList.content.size > 1) {
+                        Spacer(Modifier.size(32.dp))
+                        LineDivider(Surface1, 8)
 
-                            beforeOwnerArea(ownerShipHistoryList)
-                        }
+                        beforeOwnerArea(ownerShipHistoryList)
                     }
                 }
             }

--- a/presentation/src/main/java/com/dida/android/presentation/views/OwnerShipHistoryFragment.kt
+++ b/presentation/src/main/java/com/dida/android/presentation/views/OwnerShipHistoryFragment.kt
@@ -2,19 +2,13 @@ package com.dida.android.presentation.views
 
 import android.os.Bundle
 import android.view.View
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.material.Surface
-import androidx.compose.material3.Divider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -24,44 +18,37 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.ViewCompositionStrategy
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
-import com.dida.common.util.AppLog
-import com.dida.common.util.convertyyyyMMdd
 import com.dida.compose.theme.DidaTypography
 import com.dida.compose.theme.Surface1
 import com.dida.compose.theme.Surface4
-import com.dida.compose.theme.Surface6
 import com.dida.compose.theme.Surface8
 import com.dida.compose.theme.White
 import com.dida.compose.theme.dpToSp
 import com.dida.compose.utils.LineDivider
-import com.dida.compose.utils.VerticalDivider
 import com.dida.compose.utils.reachEnd
 import com.dida.domain.Contents
 import com.dida.domain.main.model.OwnershipHistory
-import com.dida.hot_seller.component.HotSellerItem
-import com.dida.ownership_history.R
 import com.dida.ownership_history.OwnerShipHistoryViewModel
+import com.dida.ownership_history.R
 import com.dida.ownership_history.component.OwnershipHistoryItem
 import com.dida.ownership_history.databinding.FragmentOwnershipHistoryBinding
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class OwnerShipHistoryFragment : BaseFragment<FragmentOwnershipHistoryBinding, OwnerShipHistoryViewModel>(
-    R.layout.fragment_ownership_history) {
+class OwnerShipHistoryFragment : BaseFragment<FragmentOwnershipHistoryBinding, OwnerShipHistoryViewModel>(R.layout.fragment_ownership_history) {
 
     private val TAG = "OwnerShipHistoryFragment"
 
     override val layoutResourceId: Int
         get() = R.layout.fragment_ownership_history
 
-    override val viewModel : OwnerShipHistoryViewModel by viewModels()
+    override val viewModel: OwnerShipHistoryViewModel by viewModels()
     private val navController by lazy { findNavController() }
 
     private val args: OwnerShipHistoryFragmentArgs by navArgs()
@@ -93,7 +80,7 @@ class OwnerShipHistoryFragment : BaseFragment<FragmentOwnershipHistoryBinding, O
                 LaunchedEffect(key1 = nextPage) {
                     if (nextPage) viewModel.nextPage()
                 }
-                Column{
+                Column {
                     currentOwnerArea(ownerShipHistoryList)
 
                     //소유권 내역이 하나라면 이전소유내역 비 노출
@@ -109,7 +96,7 @@ class OwnerShipHistoryFragment : BaseFragment<FragmentOwnershipHistoryBinding, O
     }
 
     @Composable
-    private fun currentOwnerArea(ownerShipHistoryList : Contents<OwnershipHistory>){
+    private fun currentOwnerArea(ownerShipHistoryList: Contents<OwnershipHistory>) {
         Column(modifier = Modifier.padding(start = 16.dp, end = 16.dp)) {
             Text(
                 text = "현재 소유자",
@@ -120,18 +107,18 @@ class OwnerShipHistoryFragment : BaseFragment<FragmentOwnershipHistoryBinding, O
                 color = White
             )
 
-            if(ownerShipHistoryList.content.isNotEmpty()){
+            if (ownerShipHistoryList.content.isNotEmpty()) {
                 OwnershipHistoryItem(
                     modifier = Modifier.padding(top = 12.dp),
                     nameColor = Color.White,
-                    item = ownerShipHistoryList.content.get(0)
+                    item = ownerShipHistoryList.content[0]
                 )
             }
         }
     }
 
     @Composable
-    private fun beforeOwnerArea(ownerShipHistoryList : Contents<OwnershipHistory>){
+    private fun beforeOwnerArea(ownerShipHistoryList: Contents<OwnershipHistory>) {
         Column(modifier = Modifier.padding(start = 16.dp, end = 16.dp)) {
             Text(
                 text = "이전 소유 내역",
@@ -148,7 +135,6 @@ class OwnerShipHistoryFragment : BaseFragment<FragmentOwnershipHistoryBinding, O
                     .padding(top = 24.dp)
             ) {
                 items(ownerShipHistoryList.size) { index ->
-                    //두번째 항목부터 보여주기 위함
                     if (index != 0) {
                         OwnershipHistoryItem(
                             modifier = Modifier,
@@ -162,9 +148,15 @@ class OwnerShipHistoryFragment : BaseFragment<FragmentOwnershipHistoryBinding, O
             }
         }
     }
+
     private fun initToolbar() {
         binding.toolbar.apply {
-            this.setTitleTextColor(ContextCompat.getColor(requireContext(), com.dida.common.R.color.white))
+            this.setTitleTextColor(
+                ContextCompat.getColor(
+                    requireContext(),
+                    com.dida.common.R.color.white
+                )
+            )
             this.setNavigationIcon(com.dida.common.R.drawable.ic_arrow_left)
             this.setNavigationOnClickListener { navController.popBackStack() }
         }

--- a/presentation/src/main/java/com/dida/android/presentation/views/OwnerShipHistoryFragment.kt
+++ b/presentation/src/main/java/com/dida/android/presentation/views/OwnerShipHistoryFragment.kt
@@ -2,11 +2,8 @@ package com.dida.android.presentation.views
 
 import android.os.Bundle
 import android.view.View
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Text
@@ -16,8 +13,8 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.viewModels
@@ -26,14 +23,11 @@ import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.dida.compose.theme.DidaTypography
 import com.dida.compose.theme.Surface1
-import com.dida.compose.theme.Surface4
-import com.dida.compose.theme.Surface8
 import com.dida.compose.theme.White
 import com.dida.compose.theme.dpToSp
 import com.dida.compose.utils.LineDivider
+import com.dida.compose.utils.VerticalDivider
 import com.dida.compose.utils.reachEnd
-import com.dida.domain.Contents
-import com.dida.domain.main.model.OwnershipHistory
 import com.dida.ownership_history.OwnerShipHistoryViewModel
 import com.dida.ownership_history.R
 import com.dida.ownership_history.component.OwnershipHistoryItem
@@ -80,15 +74,32 @@ class OwnerShipHistoryFragment : BaseFragment<FragmentOwnershipHistoryBinding, O
                 LaunchedEffect(key1 = nextPage) {
                     if (nextPage) viewModel.nextPage()
                 }
-                Column {
-                    currentOwnerArea(ownerShipHistoryList)
-
-                    //소유권 내역이 하나라면 이전소유내역 비 노출
+                LazyColumn(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(horizontal = 16.dp)
+                ) {
+                    item { OwnerTitle(isCurrent = true) }
+                    ownerShipHistoryList.content.firstOrNull()?.let {
+                        item {
+                            OwnershipHistoryItem(
+                                currentOwner = true,
+                                item = it
+                            )
+                        }
+                    }
                     if (ownerShipHistoryList.content.size > 1) {
-                        Spacer(Modifier.size(32.dp))
-                        LineDivider(Surface1, 8)
-
-                        beforeOwnerArea(ownerShipHistoryList)
+                        item { VerticalDivider(dp = 32) }
+                        item { LineDivider(Surface1, 8) }
+                        item { OwnerTitle(isCurrent = false) }
+                        items(ownerShipHistoryList.size) { index ->
+                            if (index != 0) {
+                                OwnershipHistoryItem(
+                                    currentOwner = false,
+                                    item = ownerShipHistoryList.content[index],
+                                )
+                            }
+                        }
                     }
                 }
             }
@@ -96,57 +107,15 @@ class OwnerShipHistoryFragment : BaseFragment<FragmentOwnershipHistoryBinding, O
     }
 
     @Composable
-    private fun currentOwnerArea(ownerShipHistoryList: Contents<OwnershipHistory>) {
-        Column(modifier = Modifier.padding(start = 16.dp, end = 16.dp)) {
-            Text(
-                text = "현재 소유자",
-                modifier = Modifier
-                    .padding(top = 23.dp),
-                style = DidaTypography.h3,
-                fontSize = dpToSp(dp = 18.dp),
-                color = White
-            )
-
-            if (ownerShipHistoryList.content.isNotEmpty()) {
-                OwnershipHistoryItem(
-                    modifier = Modifier.padding(top = 12.dp),
-                    nameColor = Color.White,
-                    item = ownerShipHistoryList.content[0]
-                )
-            }
-        }
-    }
-
-    @Composable
-    private fun beforeOwnerArea(ownerShipHistoryList: Contents<OwnershipHistory>) {
-        Column(modifier = Modifier.padding(start = 16.dp, end = 16.dp)) {
-            Text(
-                text = "이전 소유 내역",
-                modifier = Modifier
-                    .padding(top = 24.dp),
-                style = DidaTypography.h3,
-                fontSize = dpToSp(dp = 18.dp),
-                color = White
-            )
-
-            LazyColumn(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(top = 24.dp)
-            ) {
-                items(ownerShipHistoryList.size) { index ->
-                    if (index != 0) {
-                        OwnershipHistoryItem(
-                            modifier = Modifier,
-                            nameColor = Surface8,
-                            item = ownerShipHistoryList.content[index],
-                        )
-                        Spacer(Modifier.size(12.dp))
-                        LineDivider(Surface4, 1)
-                    }
-                }
-            }
-        }
+    private fun OwnerTitle(isCurrent: Boolean) {
+        val titleLabel = if (isCurrent) R.string.ownership_current_owner_title else R.string.ownership_before_owner_title
+        Text(
+            text = stringResource(id = titleLabel),
+            modifier = Modifier.padding(top = 23.dp),
+            style = DidaTypography.h3,
+            fontSize = dpToSp(dp = 18.dp),
+            color = White
+        )
     }
 
     private fun initToolbar() {


### PR DESCRIPTION
### 작업 내용
1. NFT상세 > 파라미터 없는 NaviagtionAction object로 수정 [7d22d34]
2. 소유권 내역 > ComposeView 겹쳐 있던 내용 수정 [6f6ef5a]
3. 소유권 내역 > 코드 정렬 [e6f910c]
4. 소유권 내역 > 이전 소유 내역 내에서만 스크롤 되던 현상 수정 & 코드 정리 [0b95884]

### 문제 화면
https://github.com/service-dida/Android/assets/84956038/fe7abacd-bd03-4bcb-954c-aa2de54e1533

### 개선 화면
https://github.com/service-dida/Android/assets/84956038/25d2af2c-ebc0-4db1-aeb9-8f48c72834ab

